### PR TITLE
feat: implement double opt-in confirmation email flow

### DIFF
--- a/app/api/confirm/route.ts
+++ b/app/api/confirm/route.ts
@@ -1,0 +1,78 @@
+import { NextRequest, NextResponse } from "next/server";
+import { createHmac, timingSafeEqual } from "crypto";
+
+function makeToken(email: string, expires: number, secret: string) {
+  return createHmac("sha256", secret).update(`${email}:${expires}`).digest("hex");
+}
+
+export async function GET(req: NextRequest) {
+  const { searchParams } = new URL(req.url);
+  const email = searchParams.get("email") ?? "";
+  const expires = parseInt(searchParams.get("expires") ?? "0", 10);
+  const token = searchParams.get("token") ?? "";
+  const siteUrl = process.env.NEXT_PUBLIC_SITE_URL || "https://amilabs.xyz";
+
+  const secret = process.env.CONFIRM_SECRET;
+  if (!secret) {
+    return html("Configuration error", "The confirmation service is not configured.", false);
+  }
+
+  // Verify expiry
+  if (!expires || Date.now() > expires) {
+    return html("Link expired", "This confirmation link has expired. Please subscribe again.", false);
+  }
+
+  // Verify HMAC using timing-safe comparison
+  const expected = makeToken(email, expires, secret);
+  let valid = false;
+  try {
+    valid = timingSafeEqual(Buffer.from(expected, "hex"), Buffer.from(token, "hex"));
+  } catch {
+    valid = false;
+  }
+
+  if (!valid) {
+    return html("Invalid link", "This confirmation link is invalid.", false);
+  }
+
+  // Activate the contact by setting unsubscribed: false
+  const apiKey = process.env.RESEND_API_KEY;
+  const audienceId = process.env.RESEND_AUDIENCE_ID;
+
+  if (!apiKey || !audienceId) {
+    return html("Configuration error", "The subscription service is not configured.", false);
+  }
+
+  const res = await fetch(`https://api.resend.com/audiences/${audienceId}/contacts`, {
+    method: "POST",
+    headers: { Authorization: `Bearer ${apiKey}`, "Content-Type": "application/json" },
+    body: JSON.stringify({ email, unsubscribed: false }),
+  });
+
+  if (!res.ok) {
+    console.error("Resend confirm error:", res.status, await res.text());
+    return html("Something went wrong", "We could not confirm your subscription. Please try again.", false);
+  }
+
+  return NextResponse.redirect(`${siteUrl}?subscribed=true`, 302);
+}
+
+function html(title: string, message: string, _success: boolean) {
+  return new NextResponse(
+    `<!DOCTYPE html>
+<html lang="en">
+<head><meta charset="UTF-8"><title>${title} — AMI Labs</title>
+<meta name="viewport" content="width=device-width,initial-scale=1">
+</head>
+<body style="margin:0;padding:0;background:#0a0a0a;font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',sans-serif;display:flex;align-items:center;justify-content:center;min-height:100vh;">
+  <div style="text-align:center;padding:40px 20px;">
+    <p style="margin:0 0 4px;font-size:12px;color:#475569;text-transform:uppercase;letter-spacing:0.1em;">AMI Labs</p>
+    <h1 style="margin:8px 0 16px;font-size:22px;color:#f1f5f9;">${title}</h1>
+    <p style="margin:0 0 28px;color:#94a3b8;font-size:14px;">${message}</p>
+    <a href="/" style="color:#64748b;font-size:13px;">← Back to site</a>
+  </div>
+</body>
+</html>`,
+    { status: 200, headers: { "Content-Type": "text/html" } }
+  );
+}

--- a/app/api/subscribe/route.ts
+++ b/app/api/subscribe/route.ts
@@ -1,4 +1,9 @@
 import { NextRequest, NextResponse } from "next/server";
+import { createHmac } from "crypto";
+
+function makeToken(email: string, expires: number, secret: string) {
+  return createHmac("sha256", secret).update(`${email}:${expires}`).digest("hex");
+}
 
 export async function POST(req: NextRequest) {
   const { email } = await req.json();
@@ -9,25 +14,92 @@ export async function POST(req: NextRequest) {
 
   const apiKey = process.env.RESEND_API_KEY;
   const audienceId = process.env.RESEND_AUDIENCE_ID;
+  const secret = process.env.CONFIRM_SECRET;
+  const siteUrl = process.env.NEXT_PUBLIC_SITE_URL || "https://amilabs.xyz";
 
-  if (!apiKey || !audienceId) {
-    console.error("RESEND_API_KEY or RESEND_AUDIENCE_ID not set.");
+  if (!apiKey || !audienceId || !secret) {
+    console.error("Missing RESEND_API_KEY, RESEND_AUDIENCE_ID, or CONFIRM_SECRET.");
     return NextResponse.json({ error: "Subscription service not configured." }, { status: 503 });
   }
 
-  const res = await fetch(`https://api.resend.com/audiences/${audienceId}/contacts`, {
+  // Add contact as unsubscribed (unconfirmed) so they won't receive broadcasts yet
+  const contactRes = await fetch(`https://api.resend.com/audiences/${audienceId}/contacts`, {
     method: "POST",
-    headers: {
-      Authorization: `Bearer ${apiKey}`,
-      "Content-Type": "application/json",
-    },
-    body: JSON.stringify({ email, unsubscribe: false }),
+    headers: { Authorization: `Bearer ${apiKey}`, "Content-Type": "application/json" },
+    body: JSON.stringify({ email, unsubscribed: true }),
   });
 
-  if (!res.ok) {
-    const body = await res.json().catch(() => ({}));
-    console.error("Resend error:", res.status, body);
+  if (!contactRes.ok) {
+    const body = await contactRes.json().catch(() => ({}));
+    console.error("Resend contact error:", contactRes.status, body);
     return NextResponse.json({ error: "Could not subscribe. Please try again." }, { status: 502 });
+  }
+
+  // Build a signed confirmation link valid for 48 hours
+  const expires = Date.now() + 48 * 60 * 60 * 1000;
+  const token = makeToken(email, expires, secret);
+  const confirmUrl = `${siteUrl}/api/confirm?email=${encodeURIComponent(email)}&expires=${expires}&token=${token}`;
+
+  // Send confirmation email
+  const emailRes = await fetch("https://api.resend.com/emails", {
+    method: "POST",
+    headers: { Authorization: `Bearer ${apiKey}`, "Content-Type": "application/json" },
+    body: JSON.stringify({
+      from: process.env.DIGEST_FROM_EMAIL || "AMI Labs <digest@amilabs.xyz>",
+      to: [email],
+      subject: "Confirm your AMI Labs subscription",
+      html: `<!DOCTYPE html>
+<html lang="en">
+<head><meta charset="UTF-8"><meta name="viewport" content="width=device-width,initial-scale=1"></head>
+<body style="margin:0;padding:0;background:#0a0a0a;font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',sans-serif;">
+  <table width="100%" cellpadding="0" cellspacing="0">
+    <tr><td align="center" style="padding:60px 16px;">
+      <table width="480" cellpadding="0" cellspacing="0" style="max-width:480px;width:100%;">
+        <tr>
+          <td style="padding:0 0 24px;">
+            <p style="margin:0;font-size:12px;color:#475569;text-transform:uppercase;letter-spacing:0.1em;">AMI Labs</p>
+          </td>
+        </tr>
+        <tr>
+          <td style="padding:0 0 16px;">
+            <h1 style="margin:0;font-size:22px;font-weight:700;color:#f1f5f9;">Confirm your subscription</h1>
+          </td>
+        </tr>
+        <tr>
+          <td style="padding:0 0 32px;">
+            <p style="margin:0;font-size:14px;color:#94a3b8;line-height:1.6;">
+              You requested to receive the AMI Labs weekly digest — news, jobs, and updates from the team.
+              Click the button below to confirm your email address.
+            </p>
+          </td>
+        </tr>
+        <tr>
+          <td style="padding:0 0 40px;">
+            <a href="${confirmUrl}"
+               style="display:inline-block;padding:12px 28px;background:#f1f5f9;color:#0a0a0a;font-weight:700;font-size:14px;text-decoration:none;border-radius:8px;">
+              Confirm subscription
+            </a>
+          </td>
+        </tr>
+        <tr>
+          <td>
+            <p style="margin:0;font-size:12px;color:#334155;">
+              This link expires in 48 hours. If you didn&rsquo;t request this, you can safely ignore this email.
+            </p>
+          </td>
+        </tr>
+      </table>
+    </td></tr>
+  </table>
+</body>
+</html>`,
+    }),
+  });
+
+  if (!emailRes.ok) {
+    const body = await emailRes.json().catch(() => ({}));
+    console.error("Resend email error:", emailRes.status, body);
+    // Contact was added — don't surface this error to the user
   }
 
   return NextResponse.json({ ok: true });

--- a/components/SubscribeForm.tsx
+++ b/components/SubscribeForm.tsx
@@ -1,11 +1,17 @@
 "use client";
 
-import { useState } from "react";
+import { useState, useEffect } from "react";
 
 export default function SubscribeForm() {
   const [email, setEmail] = useState("");
-  const [status, setStatus] = useState<"idle" | "loading" | "success" | "error">("idle");
+  const [status, setStatus] = useState<"idle" | "loading" | "success" | "confirmed" | "error">("idle");
   const [message, setMessage] = useState("");
+
+  useEffect(() => {
+    if (typeof window !== "undefined" && new URLSearchParams(window.location.search).get("subscribed") === "true") {
+      setStatus("confirmed");
+    }
+  }, []);
 
   async function handleSubmit(e: React.FormEvent) {
     e.preventDefault();
@@ -47,9 +53,13 @@ export default function SubscribeForm() {
         Get a weekly email digest of new news, jobs, and updates from AMI Labs.
       </p>
 
-      {status === "success" ? (
+      {status === "confirmed" ? (
         <p style={{ color: "#4ade80", fontSize: "0.9rem" }}>
-          You&apos;re subscribed. Check your inbox to confirm.
+          You&apos;re confirmed. You&apos;ll receive the weekly digest every Monday.
+        </p>
+      ) : status === "success" ? (
+        <p style={{ color: "#4ade80", fontSize: "0.9rem" }}>
+          Check your inbox for a confirmation email.
         </p>
       ) : (
         <form onSubmit={handleSubmit} style={{ display: "flex", gap: 8 }}>


### PR DESCRIPTION
- Subscribe route now adds contact as unsubscribed:true (pending) and sends a signed confirmation email via Resend Emails API
- New /api/confirm route verifies HMAC token (48h expiry) and activates the contact by setting unsubscribed:false
- SubscribeForm shows "check your inbox" on signup and a confirmed message when redirected back after clicking the link

Requires new env var: CONFIRM_SECRET (any random string, e.g. openssl rand -hex 32)

https://claude.ai/code/session_01UyTB2LwqLUKiGmwFxC4aHc