### PR TITLE
feat: add links and update profiles for multiple team members

### DIFF
--- a/components/ProfileClient.tsx
+++ b/components/ProfileClient.tsx
@@ -19,7 +19,7 @@ function initials(name: string) {
 }
 
 type CareerEntry = { org: string; title: string; years: string };
-type Links = { linkedin?: string; twitter?: string; scholar?: string };
+type Links = { linkedin?: string; twitter?: string; scholar?: string; github?: string; website?: string; bilibili?: string };
 
 type Member = {
   slug: string;
@@ -89,6 +89,15 @@ export default function ProfileClient({ member }: { member: Member }) {
               )}
               {member.links?.scholar && (
                 <a href={member.links.scholar} target="_blank" rel="noopener noreferrer" className="profile-link">Google Scholar</a>
+              )}
+              {member.links?.github && (
+                <a href={member.links.github} target="_blank" rel="noopener noreferrer" className="profile-link">GitHub</a>
+              )}
+              {member.links?.website && (
+                <a href={member.links.website} target="_blank" rel="noopener noreferrer" className="profile-link">Website</a>
+              )}
+              {member.links?.bilibili && (
+                <a href={member.links.bilibili} target="_blank" rel="noopener noreferrer" className="profile-link">Bilibili</a>
               )}
             </div>
           </div>

--- a/data/team.json
+++ b/data/team.json
@@ -72,7 +72,10 @@
     ],
     "links": {
       "linkedin": "https://www.linkedin.com/in/sainxie/",
-      "scholar": "https://scholar.google.com/citations?user=Z84yfY4AAAAJ"
+      "scholar": "https://scholar.google.com/citations?user=Z84yfY4AAAAJ",
+      "github": "https://github.com/s9xie",
+      "website": "https://www.sainingxie.com/",
+      "twitter": "https://x.com/sainingxie"
     },
     "semanticScholarId": "2153262"
   },
@@ -112,7 +115,7 @@
       "linkedin": "https://www.linkedin.com/in/michael-rabbat-66a00b7/",
       "scholar": "https://scholar.google.com/citations?user=cMPKe9UAAAAJ&hl=en&oi=ao"
     },
-    "semanticScholarId": "1707559"
+    "semanticScholarId": null
   },
   {
     "slug": "li-jing",
@@ -193,7 +196,9 @@
     "links": {
       "linkedin": "https://www.linkedin.com/in/sanghyun-woo-38994610a/",
       "scholar": "https://scholar.google.com/citations?user=iwBPvPIAAAAJ&hl=en",
-      "twitter": "https://twitter.com/sanghyunwoo1219"
+      "twitter": "https://x.com/sanghyunwoo1219",
+      "github": "https://github.com/shwoo1219",
+      "website": "https://sites.google.com/view/sanghyunwoo/"
     },
     "semanticScholarId": null
   },
@@ -228,7 +233,11 @@
     ],
     "links": {
       "linkedin": "https://www.linkedin.com/in/chendelong/",
-      "scholar": ""
+      "scholar": "https://scholar.google.com/citations?user=7PW095gAAAAJ",
+      "website": "https://chendelong.world/",
+      "github": "https://github.com/ChenDelong1999",
+      "twitter": "https://x.com/Delong0_0",
+      "bilibili": "https://space.bilibili.com/291158396"
     },
     "semanticScholarId": null
   },


### PR DESCRIPTION
- Saining Xie: add GitHub, website, Twitter
- Sanghyun Woo: add GitHub, website; update Twitter to x.com
- Delong Chen: add website, GitHub, Twitter, Google Scholar, Bilibili
- Michael Rabbat: set semanticScholarId null to hide publications section
- ProfileClient: add rendering support for github, website, bilibili link types

https://claude.ai/code/session_01UyTB2LwqLUKiGmwFxC4aHc