### PR TITLE
feat: add links for Brian Li and Sean Nguyen

### DIFF
--- a/data/team.json
+++ b/data/team.json
@@ -215,7 +215,11 @@
       { "org": "Microsoft Research", "title": "Research Scientist", "years": "2020–2022" }
     ],
     "links": {
-      "scholar": ""
+      "linkedin": "https://www.linkedin.com/in/brianbo1121/",
+      "scholar": "https://scholar.google.com/citations?user=1_zc1-IAAAAJ",
+      "website": "https://www.brianboli.com/",
+      "twitter": "https://x.com/Brian_Bo_Li",
+      "github": "https://github.com/luodian"
     },
     "semanticScholarId": null
   },
@@ -253,7 +257,7 @@
       { "org": "Meta AI", "title": "Executive Administrative Partner", "years": "2018–2024" }
     ],
     "links": {
-      "linkedin": ""
+      "linkedin": "https://www.linkedin.com/in/sean-nguyen-74350b26/"
     },
     "semanticScholarId": null
   }


### PR DESCRIPTION
- Brian Li: add LinkedIn, website, Twitter, GitHub, Google Scholar
- Sean Nguyen: add LinkedIn

https://claude.ai/code/session_01UyTB2LwqLUKiGmwFxC4aHc