### PR TITLE
feat: add GitHub activity feed page (/activity)

### DIFF
--- a/.github/workflows/fetch-github-activity.yml
+++ b/.github/workflows/fetch-github-activity.yml
@@ -1,0 +1,36 @@
+name: Fetch GitHub Activity
+
+on:
+  schedule:
+    - cron: "0 */6 * * *"   # Every 6 hours
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+jobs:
+  fetch:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+
+      - name: Fetch GitHub activity
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: node scripts/fetch-github-activity.js
+
+      - name: Commit updated activity
+        run: |
+          git config user.name "ami-activity-bot"
+          git config user.email "bot@ami-labs.vercel.app"
+          git add data/github-activity.json
+          if git diff --staged --quiet; then
+            echo "No changes."
+          else
+            git commit -m "chore: refresh GitHub activity [$(date -u +%Y-%m-%d\ %H:%M)]"
+            git push
+          fi

--- a/app/activity/page.tsx
+++ b/app/activity/page.tsx
@@ -1,0 +1,23 @@
+import activityData from "@/data/github-activity.json";
+import ActivityFeedClient from "@/components/ActivityFeedClient";
+import type { MemberActivity } from "@/components/ActivityFeedClient";
+
+export const metadata = {
+  title: "GitHub Activity — AMI Labs",
+  description: "Recent public GitHub activity from the AMI Labs team.",
+};
+
+export default function ActivityPage() {
+  const data = activityData as { lastFetched: string | null; members: MemberActivity[] };
+  return (
+    <>
+      <div className="page-header">
+        <div className="page-header-inner">
+          <h1>Team GitHub Activity</h1>
+          <p>Recent public activity from AMI Labs researchers</p>
+        </div>
+      </div>
+      <ActivityFeedClient members={data.members ?? []} lastFetched={data.lastFetched ?? null} />
+    </>
+  );
+}

--- a/components/ActivityFeedClient.tsx
+++ b/components/ActivityFeedClient.tsx
@@ -1,0 +1,182 @@
+"use client";
+
+import { useState } from "react";
+
+const AVATAR_COLORS = [
+  ["#6c63ff", "#a78bfa"], ["#3b82f6", "#60a5fa"], ["#10b981", "#34d399"],
+  ["#f59e0b", "#fbbf24"], ["#ef4444", "#f87171"], ["#8b5cf6", "#c084fc"],
+  ["#ec4899", "#f472b6"], ["#14b8a6", "#2dd4bf"],
+];
+
+function avatarStyle(name: string) {
+  const i = name.charCodeAt(0) % AVATAR_COLORS.length;
+  const [a, b] = AVATAR_COLORS[i];
+  return { background: `linear-gradient(135deg,${a},${b})` };
+}
+
+function initials(name: string) {
+  return name.split(/\s+/).map((w) => w[0]).join("").slice(0, 2).toUpperCase();
+}
+
+function timeAgo(timestamp: string) {
+  const diff = Date.now() - new Date(timestamp).getTime();
+  const m = Math.floor(diff / 60000);
+  if (m < 60) return `${m}m ago`;
+  const h = Math.floor(m / 60);
+  if (h < 24) return `${h}h ago`;
+  const d = Math.floor(h / 24);
+  if (d < 30) return `${d}d ago`;
+  return new Date(timestamp).toLocaleDateString("en-US", { month: "short", day: "numeric" });
+}
+
+function eventIcon(type: string) {
+  switch (type) {
+    case "PushEvent": return "⬆";
+    case "CreateEvent": return "✦";
+    case "ReleaseEvent": return "🏷";
+    case "WatchEvent": return "★";
+    case "ForkEvent": return "⑂";
+    case "IssuesEvent": return "○";
+    case "IssueCommentEvent": return "◎";
+    case "PullRequestEvent": return "↦";
+    case "PullRequestReviewEvent": return "✓";
+    case "DeleteEvent": return "✕";
+    default: return "•";
+  }
+}
+
+export type GithubEvent = {
+  type: string;
+  repo: string;
+  repoUrl: string;
+  description: string;
+  url: string;
+  timestamp: string;
+};
+
+export type MemberActivity = {
+  slug: string;
+  name: string;
+  username: string;
+  githubUrl: string;
+  events: GithubEvent[];
+};
+
+type Props = {
+  members: MemberActivity[];
+  lastFetched: string | null;
+};
+
+export default function ActivityFeedClient({ members, lastFetched }: Props) {
+  const [filterMember, setFilterMember] = useState<string>("all");
+
+  // Flatten and sort all events by timestamp
+  const allEvents = members
+    .filter((m) => filterMember === "all" || m.slug === filterMember)
+    .flatMap((m) => m.events.map((e) => ({ ...e, member: m })))
+    .sort((a, b) => new Date(b.timestamp).getTime() - new Date(a.timestamp).getTime());
+
+  return (
+    <div style={{ maxWidth: 760, margin: "0 auto", padding: "0 24px 60px" }}>
+
+      {/* filter bar */}
+      <div style={{ display: "flex", alignItems: "center", gap: 8, marginBottom: "1.5rem", flexWrap: "wrap" }}>
+        <button
+          onClick={() => setFilterMember("all")}
+          style={{
+            padding: "0.35rem 0.85rem",
+            borderRadius: 20,
+            border: "1px solid rgba(255,255,255,0.12)",
+            background: filterMember === "all" ? "rgba(255,255,255,0.12)" : "transparent",
+            color: "var(--foreground)",
+            fontSize: "0.78rem",
+            cursor: "pointer",
+          }}
+        >
+          All
+        </button>
+        {members.map((m) => (
+          <button
+            key={m.slug}
+            onClick={() => setFilterMember(m.slug)}
+            style={{
+              padding: "0.35rem 0.85rem",
+              borderRadius: 20,
+              border: "1px solid rgba(255,255,255,0.12)",
+              background: filterMember === m.slug ? "rgba(255,255,255,0.12)" : "transparent",
+              color: "var(--foreground)",
+              fontSize: "0.78rem",
+              cursor: "pointer",
+              display: "flex",
+              alignItems: "center",
+              gap: 6,
+            }}
+          >
+            <span style={{
+              width: 18, height: 18, borderRadius: "50%",
+              ...avatarStyle(m.name),
+              display: "inline-flex", alignItems: "center", justifyContent: "center",
+              fontSize: "0.55rem", fontWeight: 700, color: "#fff", flexShrink: 0,
+            }}>
+              {initials(m.name)}
+            </span>
+            {m.name.split(" ")[0]}
+          </button>
+        ))}
+        {lastFetched && (
+          <span style={{ marginLeft: "auto", fontSize: "0.72rem", color: "rgba(255,255,255,0.3)" }}>
+            Updated {timeAgo(lastFetched)}
+          </span>
+        )}
+      </div>
+
+      {/* event feed */}
+      {allEvents.length === 0 ? (
+        <p style={{ color: "rgba(255,255,255,0.3)", fontSize: "0.9rem" }}>No activity yet. Run the GitHub Action to populate data.</p>
+      ) : (
+        <div style={{ display: "flex", flexDirection: "column", gap: 0 }}>
+          {allEvents.map((e, i) => (
+            <div key={i} style={{
+              display: "flex",
+              gap: 14,
+              padding: "12px 0",
+              borderBottom: "1px solid rgba(255,255,255,0.05)",
+            }}>
+              {/* avatar */}
+              <div style={{
+                width: 32, height: 32, borderRadius: "50%",
+                ...avatarStyle(e.member.name),
+                display: "flex", alignItems: "center", justifyContent: "center",
+                fontSize: "0.65rem", fontWeight: 700, color: "#fff", flexShrink: 0, marginTop: 2,
+              }}>
+                {initials(e.member.name)}
+              </div>
+
+              {/* content */}
+              <div style={{ flex: 1, minWidth: 0 }}>
+                <div style={{ display: "flex", alignItems: "baseline", gap: 6, flexWrap: "wrap" }}>
+                  <a href={`/team/${e.member.slug}`} style={{ fontSize: "0.82rem", fontWeight: 600, color: "var(--foreground)", textDecoration: "none" }}>
+                    {e.member.name}
+                  </a>
+                  <span style={{ fontSize: "0.72rem", color: "rgba(255,255,255,0.25)" }}>
+                    {eventIcon(e.type)}
+                  </span>
+                  <a href={e.url} target="_blank" rel="noopener noreferrer" style={{ fontSize: "0.82rem", color: "rgba(255,255,255,0.7)", textDecoration: "none", minWidth: 0, overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap" }}>
+                    {e.description}
+                  </a>
+                </div>
+                <div style={{ marginTop: 3, display: "flex", alignItems: "center", gap: 8 }}>
+                  <a href={e.repoUrl} target="_blank" rel="noopener noreferrer" style={{ fontSize: "0.72rem", color: "rgba(255,255,255,0.3)", textDecoration: "none" }}>
+                    {e.repo}
+                  </a>
+                  <span style={{ fontSize: "0.68rem", color: "rgba(255,255,255,0.2)" }}>·</span>
+                  <span style={{ fontSize: "0.72rem", color: "rgba(255,255,255,0.25)" }}>{timeAgo(e.timestamp)}</span>
+                </div>
+              </div>
+            </div>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/components/Nav.tsx
+++ b/components/Nav.tsx
@@ -6,6 +6,7 @@ const links = [
   { href: "/", label: "Explorer" },
   { href: "/news", label: "News" },
   { href: "/org-chart", label: "Org Chart" },
+  { href: "/activity", label: "Activity" },
 ];
 
 export default function Nav() {

--- a/data/github-activity.json
+++ b/data/github-activity.json
@@ -1,0 +1,1 @@
+{ "lastFetched": null, "members": [] }

--- a/scripts/fetch-github-activity.js
+++ b/scripts/fetch-github-activity.js
@@ -1,0 +1,134 @@
+/**
+ * Fetches recent public GitHub events for each team member with a GitHub link
+ * and writes the results to data/github-activity.json.
+ *
+ * Run manually: node scripts/fetch-github-activity.js
+ * Requires: GITHUB_TOKEN env var (for 5000 req/hr instead of 60)
+ */
+
+const https = require("https");
+const fs = require("fs");
+const path = require("path");
+
+const TEAM_FILE = path.resolve(__dirname, "../data/team.json");
+const OUT_FILE = path.resolve(__dirname, "../data/github-activity.json");
+const TOKEN = process.env.GITHUB_TOKEN;
+const MAX_EVENTS = 15; // per user
+const DELAY_MS = 500;
+
+function get(url) {
+  return new Promise((resolve, reject) => {
+    const headers = { "User-Agent": "AMI-Labs-Site/1.0", "Accept": "application/vnd.github+json" };
+    if (TOKEN) headers["Authorization"] = `Bearer ${TOKEN}`;
+    const req = https.get(url, { headers }, (res) => {
+      let data = "";
+      res.on("data", (c) => (data += c));
+      res.on("end", () => {
+        if (res.statusCode === 404) { resolve([]); return; }
+        if (res.statusCode !== 200) { reject(new Error(`HTTP ${res.statusCode} for ${url}`)); return; }
+        resolve(JSON.parse(data));
+      });
+    });
+    req.on("error", reject);
+    req.setTimeout(15000, () => { req.destroy(); reject(new Error(`Timeout: ${url}`)); });
+  });
+}
+
+function sleep(ms) { return new Promise((r) => setTimeout(r, ms)); }
+
+function describeEvent(event) {
+  const repo = event.repo?.name || "";
+  const repoUrl = `https://github.com/${repo}`;
+  const p = event.payload || {};
+
+  switch (event.type) {
+    case "PushEvent": {
+      const n = (p.commits || []).length;
+      const branch = (p.ref || "").replace("refs/heads/", "");
+      return { description: `Pushed ${n} commit${n !== 1 ? "s" : ""} to ${branch ? `${branch} on ` : ""}${repo}`, url: repoUrl };
+    }
+    case "CreateEvent": {
+      const rt = p.ref_type;
+      if (rt === "repository") return { description: `Created repository ${repo}`, url: repoUrl };
+      if (rt === "branch") return { description: `Created branch ${p.ref} in ${repo}`, url: repoUrl };
+      if (rt === "tag") return { description: `Created tag ${p.ref} in ${repo}`, url: `${repoUrl}/releases/tag/${p.ref}` };
+      return { description: `Created ${rt} in ${repo}`, url: repoUrl };
+    }
+    case "ReleaseEvent":
+      return { description: `Released ${p.release?.tag_name || ""} on ${repo}`, url: p.release?.html_url || repoUrl };
+    case "WatchEvent":
+      return { description: `Starred ${repo}`, url: repoUrl };
+    case "ForkEvent":
+      return { description: `Forked ${repo}`, url: p.forkee?.html_url || repoUrl };
+    case "IssuesEvent":
+      return { description: `${p.action === "opened" ? "Opened" : p.action === "closed" ? "Closed" : p.action} issue #${p.issue?.number} in ${repo}`, url: p.issue?.html_url || repoUrl };
+    case "IssueCommentEvent":
+      return { description: `Commented on issue #${p.issue?.number} in ${repo}`, url: p.comment?.html_url || repoUrl };
+    case "PullRequestEvent":
+      return { description: `${p.action === "opened" ? "Opened" : p.pull_request?.merged ? "Merged" : p.action} PR #${p.pull_request?.number} in ${repo}`, url: p.pull_request?.html_url || repoUrl };
+    case "PullRequestReviewEvent":
+      return { description: `Reviewed PR #${p.pull_request?.number} in ${repo}`, url: p.pull_request?.html_url || repoUrl };
+    case "DeleteEvent":
+      return { description: `Deleted ${p.ref_type} ${p.ref} in ${repo}`, url: repoUrl };
+    case "PublicEvent":
+      return { description: `Made ${repo} public`, url: repoUrl };
+    case "MemberEvent":
+      return { description: `${p.action} member to ${repo}`, url: repoUrl };
+    case "GollumEvent":
+      return { description: `Updated wiki in ${repo}`, url: `${repoUrl}/wiki` };
+    default:
+      return { description: `Activity in ${repo}`, url: repoUrl };
+  }
+}
+
+async function fetchForMember(member) {
+  const username = member.links.github.replace("https://github.com/", "").replace(/\/$/, "");
+  const events = await get(`https://api.github.com/users/${username}/events/public?per_page=30`);
+  return (Array.isArray(events) ? events : []).slice(0, MAX_EVENTS).map((event) => {
+    const { description, url } = describeEvent(event);
+    return {
+      type: event.type,
+      repo: event.repo?.name || "",
+      repoUrl: `https://github.com/${event.repo?.name || ""}`,
+      description,
+      url,
+      timestamp: event.created_at,
+    };
+  });
+}
+
+async function main() {
+  const team = JSON.parse(fs.readFileSync(TEAM_FILE, "utf8"));
+  const members = team.filter((m) => m.links?.github);
+
+  console.log(`Fetching GitHub activity for ${members.length} members…`);
+  if (!TOKEN) console.warn("No GITHUB_TOKEN — rate limited to 60 req/hr");
+
+  const activity = [];
+
+  for (let i = 0; i < members.length; i++) {
+    const member = members[i];
+    const username = member.links.github.replace("https://github.com/", "").replace(/\/$/, "");
+    process.stdout.write(`[${member.name}] (${username}) fetching… `);
+    try {
+      const events = await fetchForMember(member);
+      console.log(`${events.length} events`);
+      activity.push({
+        slug: member.slug,
+        name: member.name,
+        username,
+        githubUrl: member.links.github,
+        events,
+      });
+    } catch (e) {
+      console.error(`FAILED: ${e.message}`);
+    }
+    if (i < members.length - 1) await sleep(DELAY_MS);
+  }
+
+  const out = { lastFetched: new Date().toISOString(), members: activity };
+  fs.writeFileSync(OUT_FILE, JSON.stringify(out, null, 2));
+  console.log(`\nWrote ${OUT_FILE}`);
+}
+
+main().catch((e) => { console.error(e); process.exit(1); });


### PR DESCRIPTION
- scripts/fetch-github-activity.js: fetches all public events for each team member with a GitHub link via GitHub Events API (15 events/user)
- fetch-github-activity.yml: runs every 6 hours, commits updates to data/github-activity.json
- ActivityFeedClient: unified event feed with per-member filter pills, event type icons, relative timestamps, links to repos/events
- /activity page: server-renders from static JSON, no runtime API calls
- Nav: added Activity link
- GITHUB_TOKEN (auto-available in Actions) used for authenticated requests (5000 req/hr limit)

https://claude.ai/code/session_01UyTB2LwqLUKiGmwFxC4aHc