### PR TITLE
fix: add Google Analytics tag to Next.js layout

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,4 +1,5 @@
 import type { Metadata } from "next";
+import Script from "next/script";
 import "./globals.css";
 import Nav from "@/components/Nav";
 
@@ -11,6 +12,16 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
   return (
     <html lang="en">
       <body>
+        <Script
+          src="https://www.googletagmanager.com/gtag/js?id=G-GMKGT0Y1EC"
+          strategy="afterInteractive"
+        />
+        <Script id="gtag-init" strategy="afterInteractive">{`
+          window.dataLayer = window.dataLayer || [];
+          function gtag(){dataLayer.push(arguments);}
+          gtag('js', new Date());
+          gtag('config', 'G-GMKGT0Y1EC');
+        `}</Script>
         <Nav />
         {children}
       </body>


### PR DESCRIPTION
The gtag snippet was only in the static index.html (ignored by Next.js). Moved it into app/layout.tsx using next/script with afterInteractive strategy so it fires on every page.

https://claude.ai/code/session_01UyTB2LwqLUKiGmwFxC4aHc