### PR TITLE
Add AMI Labs HR Ops hiring news entry

### DIFF
--- a/data/news.json
+++ b/data/news.json
@@ -1,5 +1,17 @@
 [
   {
+    "id": "f3a8d2e1-5b4c-4789-a6f0-9e7d1c3b8520",
+    "title": "AMI Labs is hiring an HR Ops in Paris",
+    "source": "AMI Labs Jobs",
+    "url": "https://jobs.ashbyhq.com/ami/c191952c-94f0-4adb-b22c-525028beb2b6",
+    "publishedAt": "2026-03-17",
+    "summary": "AMI Labs has posted a new HR Ops position within the General and Administration department, based in Paris. The role reflects the company's continued organisational build-out following its $1 billion fundraise in early 2026. Applications can be submitted directly via the AMI Labs Ashby jobs board.",
+    "tags": [
+      "hiring"
+    ],
+    "addedAt": "2026-03-17T12:43:13.000Z"
+  },
+  {
     "id": "1edb1158-dab1-4a4d-8271-204791610524",
     "title": "Recap: Europe’s top 10 funding rounds this week (9–15 March)",
     "source": "The Next Web",


### PR DESCRIPTION
## Summary
Added a new news entry to the news feed documenting AMI Labs' HR Ops job posting in Paris.

## Changes
- Added a new news article entry for "AMI Labs is hiring an HR Ops in Paris"
- Entry includes:
  - Unique identifier (UUID format)
  - Job posting title and source attribution
  - Direct link to the Ashby jobs board listing
  - Publication date of March 17, 2026
  - Summary describing the HR Ops role in the General and Administration department, contextualizing it within AMI Labs' organizational growth following their $1B fundraise
  - "hiring" tag for categorization
  - Timestamp of when the entry was added to the news feed

## Details
The entry is positioned at the top of the news.json array as the most recent news item, maintaining reverse chronological ordering.

https://claude.ai/code/session_01Fuy6sARBeJcm1dwh7EiB2p