### PR TITLE
feat: add company registration filings as news; rename regulatory → a…

### DIFF
--- a/components/NewsPageClient.tsx
+++ b/components/NewsPageClient.tsx
@@ -13,10 +13,10 @@ type Article = {
 };
 
 const TAG_STYLES: Record<string, { bg: string; color: string; border: string }> = {
-  funding:    { bg: "#1a2a1a", color: "var(--green)",  border: "#2a4a2a" },
-  research:   { bg: "#1a1a2a", color: "var(--blue)",   border: "#2a2a4a" },
-  hiring:     { bg: "#2a1a2a", color: "var(--pink)",   border: "#4a2a4a" },
-  regulatory: { bg: "#2a1a1a", color: "var(--orange)", border: "#4a2a1a" },
+  funding:       { bg: "#1a2a1a", color: "var(--green)",  border: "#2a4a2a" },
+  research:      { bg: "#1a1a2a", color: "var(--blue)",   border: "#2a2a4a" },
+  hiring:        { bg: "#2a1a2a", color: "var(--pink)",   border: "#4a2a4a" },
+  administrative:{ bg: "#2a1a1a", color: "var(--orange)", border: "#4a2a1a" },
 };
 
 function TagBadge({ tag }: { tag: string }) {
@@ -35,7 +35,7 @@ function formatDate(dateStr: string) {
   return new Date(dateStr).toLocaleDateString("en-US", { year: "numeric", month: "short", day: "numeric" });
 }
 
-const ALL_TAGS = ["funding", "research", "hiring", "regulatory"];
+const ALL_TAGS = ["funding", "research", "hiring", "administrative"];
 
 export default function NewsPageClient({ articles }: { articles: Article[] }) {
   const [query, setQuery] = useState("");

--- a/data/news.json
+++ b/data/news.json
@@ -1,5 +1,25 @@
 [
   {
+    "id": "b3e1a2d4-9f5c-4812-a7e0-6c3d8b1f2940",
+    "title": "PengyouCo (now AMI Labs) incorporated as SAS in Paris",
+    "source": "Tribunal de commerce de Paris (via Pappers)",
+    "url": "https://www.pappers.fr/entreprise/advanced-machine-intelligence-994675254",
+    "publishedAt": "2025-12-03",
+    "summary": "PengyouCo — the legal entity that became AMI Labs (Advanced Machine Intelligence) — was incorporated on 3 December 2025 as a Société par Actions Simplifiée (SAS) with €10,000 share capital. The company was registered at 51 rue de Seine, Paris 6e, with Gérard Lebrun (father of CEO Alexandre LeBrun) as sole founding shareholder and first president. Its stated corporate purpose covers AI model development, software engineering, and R&D.",
+    "tags": ["administrative"],
+    "addedAt": "2025-12-10T00:00:00.000Z"
+  },
+  {
+    "id": "c4f2b3e5-0a6d-4923-b8f1-7d4e9c2a3051",
+    "title": "PengyouCo (AMI Labs) updates articles of association — early share restructuring",
+    "source": "Tribunal de commerce de Paris (via Pappers)",
+    "url": "https://www.pappers.fr/entreprise/advanced-machine-intelligence-994675254",
+    "publishedAt": "2025-12-19",
+    "summary": "PengyouCo updated its articles of association on 19 December 2025, restructuring its 1,000,000 shares: ordinary shares were increased from 33,500 to 71,750, while SP preference shares (which carry 10× voting rights) were adjusted to 928,250. The update was certified by founding president Gérard Lebrun and preceded the company's January 2026 fundraise announcement under the AMI Labs brand.",
+    "tags": ["administrative"],
+    "addedAt": "2025-12-22T00:00:00.000Z"
+  },
+  {
     "id": "f3a8d2e1-5b4c-4789-a6f0-9e7d1c3b8520",
     "title": "AMI Labs is hiring an HR Ops in Paris",
     "source": "AMI Labs Jobs",

--- a/scripts/update-news.js
+++ b/scripts/update-news.js
@@ -84,7 +84,7 @@ function inferTags(title) {
   if (/rais|fund|invest|valuat|billion|million/.test(t)) tags.push("funding");
   if (/research|paper|model|jepa|science|publish/.test(t)) tags.push("research");
   if (/hir|join|appoint|team/.test(t)) tags.push("hiring");
-  if (/regulat|legal|filing|compliance/.test(t)) tags.push("regulatory");
+  if (/regulat|legal|filing|compliance|incorporat|statut|registr|kbis/.test(t)) tags.push("administrative");
   return tags;
 }
 


### PR DESCRIPTION
…dministrative

- Rename 'regulatory' tag to 'administrative' across NewsPageClient and update-news.js (better reflects corporate formation/filing documents vs compliance/oversight matters)
- Expand inferTags regex to catch incorporation/registration language
- Add 2 news items for PengyouCo filings (the legal shell that became AMI Labs):
  - 3 Dec 2025: Acte constitutif — SAS incorporation, Gérard Lebrun as founding president
  - 19 Dec 2025: Updated articles — share restructuring ahead of the fundraise
- Source links point to the company's Pappers page (public record, direct PDF downloads)

https://claude.ai/code/session_01Fuy6sARBeJcm1dwh7EiB2p