### PR TITLE
Add /investors page — move explorer to dedicated route

### DIFF
--- a/app/investors/page.tsx
+++ b/app/investors/page.tsx
@@ -1,0 +1,14 @@
+import type { Metadata } from "next";
+import investorsData from "@/data/investors.json";
+import teamData from "@/data/team.json";
+import ExplorerClient from "@/components/ExplorerClient";
+
+export const metadata: Metadata = {
+  title: "Investors — AMI Labs Intelligence Hub",
+  description:
+    "Explore AMI Labs' investors and strategic partners — corporate backers, venture capital firms, and business angels behind the $1.03B seed round.",
+};
+
+export default function InvestorsPage() {
+  return <ExplorerClient investors={investorsData} team={teamData} />;
+}


### PR DESCRIPTION
Creates app/investors/page.tsx as a server component wrapping the existing ExplorerClient. The full search/filter investor and team explorer is now accessible at /investors, completing the nav link added during the homepage redesign. No other files changed.

https://claude.ai/code/session_01LdfP4BjZTQZriPvfREKpkU