### PR TITLE
Add /docs page with public pitchdeck library

### DIFF
--- a/app/docs/page.tsx
+++ b/app/docs/page.tsx
@@ -1,0 +1,13 @@
+import type { Metadata } from "next";
+import docsData from "@/data/documents.json";
+import DocsClient from "@/components/DocsClient";
+
+export const metadata: Metadata = {
+  title: "Documents — AMI Labs Intelligence Hub",
+  description:
+    "Official AMI Labs documents — pitchdeck, reports, and public filings.",
+};
+
+export default function DocsPage() {
+  return <DocsClient documents={docsData} />;
+}

--- a/app/globals.css
+++ b/app/globals.css
@@ -1190,3 +1190,177 @@ input[type="search"]::placeholder { color: var(--muted); }
   .footer-links { display: none; }
   .footer-powered { margin-left: 0; }
 }
+
+/* ─────────────────────────────────────────
+   DOCS PAGE
+───────────────────────────────────────── */
+.docs-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(320px, 1fr));
+  gap: 16px;
+  margin-bottom: 40px;
+}
+
+.doc-card {
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: 14px;
+  padding: 20px 22px;
+  display: flex;
+  gap: 16px;
+  transition: border-color 0.2s, box-shadow 0.2s, transform 0.15s;
+}
+.doc-card:hover {
+  border-color: rgba(167, 139, 250, 0.45);
+  box-shadow: 0 4px 24px rgba(0, 0, 0, 0.35), 0 0 0 1px var(--accent-dim);
+  transform: translateY(-2px);
+}
+
+.doc-card-icon {
+  font-size: 2rem;
+  flex-shrink: 0;
+  line-height: 1;
+  margin-top: 2px;
+}
+
+.doc-card-body {
+  flex: 1;
+  min-width: 0;
+}
+
+.doc-card-title {
+  font-size: 1rem;
+  font-weight: 700;
+  color: var(--text);
+  letter-spacing: -0.015em;
+  margin-bottom: 4px;
+}
+
+.doc-card-meta {
+  font-size: 0.73rem;
+  color: var(--accent2);
+  font-weight: 500;
+  margin-bottom: 8px;
+  letter-spacing: 0.02em;
+}
+
+.doc-card-desc {
+  font-size: 0.82rem;
+  color: var(--muted);
+  line-height: 1.55;
+  margin-bottom: 14px;
+}
+
+.doc-card-actions {
+  display: flex;
+  gap: 8px;
+  flex-wrap: wrap;
+}
+
+.doc-btn {
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+  font-family: inherit;
+  font-size: 0.78rem;
+  font-weight: 600;
+  padding: 7px 14px;
+  border-radius: 8px;
+  cursor: pointer;
+  transition: all 0.15s;
+  text-decoration: none;
+  border: 1px solid transparent;
+  white-space: nowrap;
+}
+
+.doc-btn-view {
+  background: var(--accent-dim);
+  border-color: rgba(167, 139, 250, 0.3);
+  color: var(--accent2);
+}
+.doc-btn-view:hover {
+  background: var(--accent);
+  border-color: var(--accent);
+  color: #fff;
+}
+
+.doc-btn-dl {
+  background: var(--surface2);
+  border-color: var(--border);
+  color: var(--text-dim);
+}
+.doc-btn-dl:hover {
+  border-color: var(--accent2);
+  color: var(--accent2);
+}
+
+/* PDF Viewer */
+.docs-viewer {
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: 14px;
+  overflow: hidden;
+  margin-bottom: 28px;
+}
+
+.docs-viewer-bar {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  padding: 10px 16px;
+  border-bottom: 1px solid var(--border);
+  background: var(--surface2);
+  flex-wrap: wrap;
+}
+
+.docs-viewer-title {
+  font-size: 0.85rem;
+  font-weight: 600;
+  color: var(--text);
+}
+
+.docs-viewer-label {
+  font-size: 0.72rem;
+  color: var(--muted);
+  background: var(--bg);
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  padding: 2px 8px;
+  font-weight: 500;
+}
+
+.docs-viewer-download,
+.docs-viewer-close {
+  margin-left: auto;
+  font-family: inherit;
+  font-size: 0.78rem;
+  font-weight: 600;
+  padding: 5px 12px;
+  border-radius: 7px;
+  cursor: pointer;
+  transition: all 0.15s;
+  text-decoration: none;
+  border: 1px solid var(--border);
+  background: var(--surface);
+  color: var(--text-dim);
+}
+.docs-viewer-download { margin-left: auto; color: var(--accent2); border-color: rgba(167, 139, 250, 0.3); background: var(--accent-dim); }
+.docs-viewer-download:hover { background: var(--accent); border-color: var(--accent); color: #fff; }
+.docs-viewer-close { margin-left: 6px; }
+.docs-viewer-close:hover { border-color: var(--accent2); color: var(--text); }
+
+.docs-viewer-iframe {
+  width: 100%;
+  height: 78vh;
+  min-height: 480px;
+  border: none;
+  display: block;
+  background: #fff;
+}
+
+.empty-state {
+  text-align: center;
+  color: var(--muted);
+  font-size: 0.9rem;
+  padding: 60px 0;
+}

--- a/components/DocsClient.tsx
+++ b/components/DocsClient.tsx
@@ -1,0 +1,130 @@
+"use client";
+
+import { useState } from "react";
+
+interface Document {
+  id: string;
+  title: string;
+  description: string;
+  category: string;
+  date: string;
+  filename: string;
+  label: string;
+  access: string;
+}
+
+interface DocsClientProps {
+  documents: Document[];
+}
+
+const CATEGORY_OPTIONS = [
+  { key: "all", label: "All" },
+  { key: "pitchdeck", label: "Pitchdeck" },
+  { key: "report", label: "Reports" },
+  { key: "filing", label: "Filings" },
+];
+
+function formatDate(dateStr: string) {
+  return new Date(dateStr).toLocaleDateString("en-US", {
+    year: "numeric",
+    month: "long",
+  });
+}
+
+export default function DocsClient({ documents }: DocsClientProps) {
+  const [activeCategory, setActiveCategory] = useState("all");
+  const [viewing, setViewing] = useState<Document | null>(null);
+
+  const filtered =
+    activeCategory === "all"
+      ? documents
+      : documents.filter((d) => d.category === activeCategory);
+
+  return (
+    <>
+      <div className="page-header">
+        <div className="page-header-inner">
+          <h1>Documents</h1>
+          <p>Official AMI Labs public documents — pitchdecks, reports, and filings.</p>
+        </div>
+      </div>
+
+      <main>
+        {/* Viewer */}
+        {viewing && (
+          <div className="docs-viewer">
+            <div className="docs-viewer-bar">
+              <span className="docs-viewer-title">{viewing.title}</span>
+              <span className="docs-viewer-label">{viewing.label}</span>
+              <a
+                href={`/documents/${viewing.filename}`}
+                download
+                className="docs-viewer-download"
+              >
+                ↓ Download
+              </a>
+              <button
+                className="docs-viewer-close"
+                onClick={() => setViewing(null)}
+              >
+                ✕ Close
+              </button>
+            </div>
+            <iframe
+              src={`/documents/${viewing.filename}`}
+              className="docs-viewer-iframe"
+              title={viewing.title}
+            />
+          </div>
+        )}
+
+        {/* Filters */}
+        <div className="controls">
+          {CATEGORY_OPTIONS.map((opt) => (
+            <button
+              key={opt.key}
+              className={`filter-btn${activeCategory === opt.key ? " active" : ""}`}
+              onClick={() => setActiveCategory(opt.key)}
+            >
+              {opt.label}
+            </button>
+          ))}
+          <span className="result-count">{filtered.length} document{filtered.length !== 1 ? "s" : ""}</span>
+        </div>
+
+        {/* Cards */}
+        <div className="docs-grid">
+          {filtered.map((doc) => (
+            <div key={doc.id} className="doc-card">
+              <div className="doc-card-icon">📄</div>
+              <div className="doc-card-body">
+                <div className="doc-card-title">{doc.title}</div>
+                <div className="doc-card-meta">{doc.label} · {formatDate(doc.date)}</div>
+                <div className="doc-card-desc">{doc.description}</div>
+                <div className="doc-card-actions">
+                  <button
+                    className="doc-btn doc-btn-view"
+                    onClick={() => setViewing(viewing?.id === doc.id ? null : doc)}
+                  >
+                    {viewing?.id === doc.id ? "Close viewer" : "View"}
+                  </button>
+                  <a
+                    href={`/documents/${doc.filename}`}
+                    download
+                    className="doc-btn doc-btn-dl"
+                  >
+                    Download PDF
+                  </a>
+                </div>
+              </div>
+            </div>
+          ))}
+        </div>
+
+        {filtered.length === 0 && (
+          <div className="empty-state">No documents in this category yet.</div>
+        )}
+      </main>
+    </>
+  );
+}

--- a/components/Nav.tsx
+++ b/components/Nav.tsx
@@ -9,6 +9,7 @@ const links = [
   { href: "/investors", label: "Investors" },
   { href: "/org-chart", label: "Team" },
   { href: "/activity", label: "Activity" },
+  { href: "/docs", label: "Docs" },
 ];
 
 export default function Nav() {

--- a/data/documents.json
+++ b/data/documents.json
@@ -1,0 +1,12 @@
+[
+  {
+    "id": "pitchdeck-dec-2025-v1",
+    "title": "AMI Labs Pitchdeck",
+    "description": "Official investor pitchdeck — December 2025, Version 1. Covers the company vision, world model thesis, product roadmap, and team.",
+    "category": "pitchdeck",
+    "date": "2025-12-01",
+    "filename": "AMI-Labs-Pitchdeck---Dec-2025---V1.pdf",
+    "label": "Dec 2025 · V1",
+    "access": "public"
+  }
+]


### PR DESCRIPTION
- New /docs route with DocsClient component: card grid, PDF inline viewer, download button
- data/documents.json defines available documents (AMI-Labs-Pitchdeck---Dec-2025---V1.pdf)
- public/documents/ folder for serving PDFs statically
- "Docs" link added to Nav
- Docs-specific CSS added to globals.css (doc-card, docs-viewer, etc.)

Place AMI-Labs-Pitchdeck---Dec-2025---V1.pdf in public/documents/ to activate.

https://claude.ai/code/session_01LdfP4BjZTQZriPvfREKpkU