### PR TITLE
Add /explainers page with pitchdeck embed and editorial cards

### DIFF
--- a/app/explainers/page.tsx
+++ b/app/explainers/page.tsx
@@ -1,0 +1,14 @@
+import type { Metadata } from "next";
+import docsData from "@/data/documents.json";
+import ExplainersClient from "@/components/ExplainersClient";
+
+export const metadata: Metadata = {
+  title: "Explainers — AMI Labs Intelligence Hub",
+  description:
+    "What is AMI Labs? What are World Models? Learn about Advanced Machine Intelligence and the science behind it.",
+};
+
+export default function ExplainersPage() {
+  const pitchdeck = docsData.find((d) => d.category === "pitchdeck") ?? null;
+  return <ExplainersClient pitchdeck={pitchdeck} />;
+}

--- a/app/globals.css
+++ b/app/globals.css
@@ -1192,6 +1192,118 @@ input[type="search"]::placeholder { color: var(--muted); }
 }
 
 /* ─────────────────────────────────────────
+   EXPLAINERS PAGE
+───────────────────────────────────────── */
+.explainer-embed-section {
+  margin-bottom: 44px;
+}
+
+.explainer-embed {
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: 14px;
+  overflow: hidden;
+}
+
+.explainer-embed-bar {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  padding: 10px 16px;
+  border-bottom: 1px solid var(--border);
+  background: var(--surface2);
+  flex-wrap: wrap;
+}
+
+.explainer-embed-title {
+  font-size: 0.875rem;
+  font-weight: 600;
+  color: var(--text);
+}
+
+.explainer-embed-label {
+  font-size: 0.72rem;
+  color: var(--muted);
+  background: var(--bg);
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  padding: 2px 8px;
+  font-weight: 500;
+}
+
+.explainer-embed-dl {
+  margin-left: auto;
+  font-size: 0.78rem;
+  font-weight: 600;
+  padding: 5px 12px;
+  border-radius: 7px;
+  background: var(--accent-dim);
+  border: 1px solid rgba(167, 139, 250, 0.3);
+  color: var(--accent2);
+  text-decoration: none;
+  transition: all 0.15s;
+  white-space: nowrap;
+}
+.explainer-embed-dl:hover {
+  background: var(--accent);
+  border-color: var(--accent);
+  color: #fff;
+}
+
+.explainer-embed-iframe {
+  width: 100%;
+  height: 80vh;
+  min-height: 520px;
+  border: none;
+  display: block;
+  background: #fff;
+}
+
+.explainers-cards {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(340px, 1fr));
+  gap: 16px;
+  margin-bottom: 0;
+}
+
+.explainer-article-card {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
+.explainer-article-icon {
+  font-size: 1.75rem;
+  line-height: 1;
+}
+
+.explainer-article-card .card-name {
+  font-size: 1.05rem;
+  font-weight: 700;
+  letter-spacing: -0.02em;
+}
+
+.explainer-article-card .card-body p {
+  font-size: 0.85rem;
+  color: var(--muted);
+  line-height: 1.65;
+}
+
+.explainer-article-links {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  margin-top: 4px;
+  padding-top: 12px;
+  border-top: 1px solid var(--border);
+}
+
+@media (max-width: 680px) {
+  .explainer-embed-iframe { height: 60vh; min-height: 360px; }
+  .explainers-cards { grid-template-columns: 1fr; }
+}
+
+/* ─────────────────────────────────────────
    DOCS PAGE
 ───────────────────────────────────────── */
 .docs-grid {

--- a/components/ExplainersClient.tsx
+++ b/components/ExplainersClient.tsx
@@ -1,0 +1,134 @@
+import Link from "next/link";
+
+interface Document {
+  id: string;
+  title: string;
+  description: string;
+  category: string;
+  date: string;
+  filename: string;
+  label: string;
+  access: string;
+}
+
+interface ExplainersClientProps {
+  pitchdeck: Document | null;
+}
+
+export default function ExplainersClient({ pitchdeck }: ExplainersClientProps) {
+  return (
+    <>
+      <div className="page-header">
+        <div className="page-header-inner">
+          <h1>Explainers</h1>
+          <p>What is AMI Labs building, and why does it matter?</p>
+        </div>
+      </div>
+
+      <main>
+        {/* ── Pitchdeck embed ── */}
+        {pitchdeck && (
+          <section className="explainer-embed-section">
+            <div className="section-header" style={{ marginTop: 0 }}>
+              <div className="section-icon" style={{ background: "var(--accent-dim)" }}>📄</div>
+              <h2>Pitchdeck</h2>
+              <span className="section-count">{pitchdeck.label}</span>
+            </div>
+
+            <div className="explainer-embed">
+              <div className="explainer-embed-bar">
+                <span className="explainer-embed-title">{pitchdeck.title}</span>
+                <span className="explainer-embed-label">{pitchdeck.label}</span>
+                <a
+                  href={`/documents/${pitchdeck.filename}`}
+                  download
+                  className="explainer-embed-dl"
+                >
+                  ↓ Download PDF
+                </a>
+              </div>
+              <iframe
+                src={`/documents/${pitchdeck.filename}`}
+                className="explainer-embed-iframe"
+                title={pitchdeck.title}
+              />
+            </div>
+          </section>
+        )}
+
+        {/* ── Editorial cards ── */}
+        <div className="section-header">
+          <div className="section-icon" style={{ background: "var(--electric-dim)" }}>🧠</div>
+          <h2>Background</h2>
+        </div>
+
+        <div className="explainers-cards">
+
+          <div className="card explainer-article-card">
+            <div className="explainer-article-icon">🧠</div>
+            <div className="card-name">What is AMI Labs?</div>
+            <div className="card-body">
+              <p>
+                Advanced Machine Intelligence (AMI Labs) is a Paris-based AI research company
+                founded in 2025 by Yann LeCun — Chief AI Scientist at Meta — and entrepreneur
+                Alexandre LeBrun. The company raised a $1.03B seed round at a $3.5B valuation,
+                co-led by HIRO Capital, with participation from Toyota Ventures, Daphni,
+                Founders Future, and others.
+              </p>
+              <p style={{ marginTop: 10 }}>
+                AMI Labs' mission is to build AI systems that understand the real world — not just
+                language. Where current large language models excel at text prediction, AMI targets
+                a deeper form of intelligence: systems that can reason about physics, causality,
+                and the dynamics of the physical environment.
+              </p>
+            </div>
+            <div className="explainer-article-links">
+              <Link href="/org-chart" className="card-link">👥 Meet the team →</Link>
+              <Link href="/investors" className="card-link">💼 Investors →</Link>
+              <Link href="/timeline" className="card-link">📅 Timeline →</Link>
+            </div>
+          </div>
+
+          <div className="card explainer-article-card">
+            <div className="explainer-article-icon">🌐</div>
+            <div className="card-name">What are World Models?</div>
+            <div className="card-body">
+              <p>
+                A World Model is an AI system that learns an internal representation of how the
+                world works. Rather than mapping inputs to outputs via pattern matching, a world
+                model builds a compressed, structured understanding of reality — enabling it to
+                <em> predict</em>, <em>plan</em>, and <em>reason</em> about situations it has
+                never directly observed.
+              </p>
+              <p style={{ marginTop: 10 }}>
+                Yann LeCun has argued that world models are the missing ingredient for truly
+                general AI. Current LLMs have no grounding in physical reality: they cannot
+                mentally simulate pouring water into a glass, or anticipate the consequences of
+                pushing an object off a table. World models aim to fix this by learning from
+                sensory experience — video, audio, proprioception — rather than text alone.
+              </p>
+              <p style={{ marginTop: 10 }}>
+                AMI Labs' architecture, described internally as <strong>Alpha Intelligence</strong>,
+                is designed around this thesis: a hierarchical latent-space model trained on
+                multimodal real-world data, capable of building and querying an internal
+                world representation at inference time.
+              </p>
+            </div>
+            <div className="explainer-article-links">
+              <Link href="/news" className="card-link">📰 Latest research news →</Link>
+              <Link href="/timeline" className="card-link">📅 Key milestones →</Link>
+            </div>
+          </div>
+
+        </div>
+
+        {/* ── Footer link to docs ── */}
+        <div style={{ marginTop: 48, paddingTop: 24, borderTop: "1px solid var(--border)", display: "flex", justifyContent: "flex-end" }}>
+          <Link href="/docs" className="card-link" style={{ fontSize: "0.82rem" }}>
+            All documents →
+          </Link>
+        </div>
+      </main>
+    </>
+  );
+}


### PR DESCRIPTION
- New /explainers route: page header, full-height pitchdeck iframe embed (from documents.json), two editorial cards expanding on "What is AMI Labs?" and "What are World Models?"
- ExplainersClient is a plain server-renderable component (no state needed)
- Pitchdeck passed as prop from server component via documents.json lookup
- New CSS: .explainer-embed, .explainer-embed-bar, .explainer-embed-iframe, .explainers-cards
- "All documents →" footer link to /docs

https://claude.ai/code/session_01LdfP4BjZTQZriPvfREKpkU