### PR TITLE
Rebrand as French Tech Journal editorial tracker

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -7,8 +7,8 @@ import Nav from "@/components/Nav";
 const inter = Inter({ subsets: ["latin"], variable: "--font-inter" });
 
 export const metadata: Metadata = {
-  title: "AMI Labs — Intelligence Hub",
-  description: "Comprehensive tracker for Advanced Machine Intelligence (AMI Labs) — news, team profiles, investors, and org chart.",
+  title: "AMI Labs Tracker — The French Tech Journal",
+  description: "Independent editorial tracker for AMI Labs (Advanced Machine Intelligence) — news, team, investors, funding, and milestones. A special project by The French Tech Journal.",
 };
 
 export default function RootLayout({ children }: { children: React.ReactNode }) {

--- a/components/ExplainerStrip.tsx
+++ b/components/ExplainerStrip.tsx
@@ -5,9 +5,9 @@ const explainers = [
     icon: "🧠",
     title: "What is AMI Labs?",
     description:
-      "Advanced Machine Intelligence is building the next generation of AI — systems that reason about the physical world, not just language. Founded in 2025 by Yann LeCun and Alexandre LeBrun.",
+      "Advanced Machine Intelligence is one of the most closely watched AI startups in the world. Founded in 2025 by Yann LeCun and Alexandre LeBrun, it's building AI systems that reason about the physical world, not just language.",
     href: "/explainers",
-    linkLabel: "Our mission →",
+    linkLabel: "About the company →",
   },
   {
     icon: "🌐",
@@ -21,7 +21,7 @@ const explainers = [
     icon: "👥",
     title: "The Team",
     description:
-      "A world-class team of researchers, engineers, and operators across Paris, New York, Montreal, and Singapore — united by a shared conviction that AI can do far more than generate text.",
+      "AMI Labs has assembled researchers, engineers, and operators across Paris, New York, Montreal, and Singapore. We track every key hire and leadership change as the team grows.",
     href: "/org-chart",
     linkLabel: "Meet the team →",
   },
@@ -31,7 +31,7 @@ export default function ExplainerStrip() {
   return (
     <section className="home-section">
       <div className="home-section-header">
-        <span className="home-section-label">About AMI Labs</span>
+        <span className="home-section-label">What You Need to Know</span>
       </div>
       <div className="explainer-strip">
         {explainers.map((card) => (

--- a/components/Hero.tsx
+++ b/components/Hero.tsx
@@ -9,14 +9,13 @@ export default function Hero() {
 
       {/* Frosted glass card */}
       <div className="hero-glass">
-        <div className="hero-eyebrow">Advanced Machine Intelligence</div>
+        <div className="hero-eyebrow">A Special Project by The French Tech Journal</div>
         <h1 className="hero-title">
-          Building AI That<br />
-          <span className="hero-title-gradient">Understands the World</span>
+          Tracking AMI Labs —<br />
+          <span className="hero-title-gradient">One of AI&apos;s Most Watched Companies</span>
         </h1>
         <p className="hero-description">
-          AMI Labs is developing World Models — AI systems that reason about the physical
-          world, go beyond language, and unlock the next frontier of machine intelligence.
+          AMI Labs is betting that the future of AI isn&apos;t language models: machines that understand the physical world. We&apos;re tracking every milestone, hire, investor, and research development so you don&apos;t have to.
         </p>
         <div className="hero-ctas">
           <Link href="/news" className="hero-cta-primary">

--- a/components/HomepageClient.tsx
+++ b/components/HomepageClient.tsx
@@ -51,8 +51,7 @@ export default function HomepageClient({ news, milestones }: HomepageClientProps
             <span className="home-section-label">Intelligence Digest</span>
           </div>
           <p className="subscribe-intro">
-            Stay ahead of every AMI Labs development — research breakthroughs, hiring news,
-            funding updates, and more. Delivered every Monday.
+            Every Monday, The French Tech Journal sends a digest of the latest AMI Labs news — funding, research, hiring, and more. Independent coverage. No spin.
           </p>
           <SubscribeForm />
         </section>
@@ -65,7 +64,7 @@ export default function HomepageClient({ news, milestones }: HomepageClientProps
               <span className="nav-logo-dot" />
               AMI Labs
             </span>
-            <span className="footer-tagline">Advanced Machine Intelligence</span>
+            <span className="footer-tagline">An editorial tracker by The French Tech Journal</span>
           </div>
           <div className="footer-links">
             <a href="/news">News</a>


### PR DESCRIPTION
## Summary
This PR rebrands the AMI Labs website from a standalone "Intelligence Hub" to an editorial tracker project by The French Tech Journal. The changes update messaging, positioning, and branding throughout the site to reflect this new editorial perspective.

## Key Changes
- **Hero section**: Updated eyebrow, headline, and description to position the site as a French Tech Journal special project tracking AMI Labs
- **Explainer cards**: Refined descriptions to emphasize independent editorial coverage and tracking of company developments (hires, funding, research)
- **Section labels**: Changed "About AMI Labs" to "What You Need to Know" for better editorial framing
- **Newsletter copy**: Updated to emphasize independent coverage with "No spin" messaging and French Tech Journal branding
- **Footer**: Changed tagline from "Advanced Machine Intelligence" to "An editorial tracker by The French Tech Journal"
- **Metadata**: Updated page title and description to reflect French Tech Journal branding and editorial tracker positioning

## Implementation Details
All changes are content-focused updates to existing components with no structural or functional modifications. The rebranding maintains the same component architecture while shifting the narrative from a company-owned hub to independent editorial coverage.

https://claude.ai/code/session_016P7Xhmy2hsgrHKbcP8zE97