### PR TITLE
Fix text contrast, favicon, and Saining Xie scholar link

### DIFF
--- a/app/icon.svg
+++ b/app/icon.svg
@@ -1,0 +1,25 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32" fill="none">
+  <!-- Background circle -->
+  <circle cx="16" cy="16" r="16" fill="#FFFCF5"/>
+
+  <!-- Telescope body (main tube) -->
+  <rect x="6" y="13" width="14" height="6" rx="2" fill="#946B2D" transform="rotate(-30 13 16)"/>
+
+  <!-- Eyepiece (smaller tube at left) -->
+  <rect x="4" y="15" width="7" height="4" rx="1.5" fill="#B8860B" transform="rotate(-30 7.5 17)"/>
+
+  <!-- Objective lens (larger end on right) -->
+  <rect x="18" y="11" width="5" height="8" rx="2" fill="#C8962E" transform="rotate(-30 20.5 15)"/>
+
+  <!-- Tripod leg left -->
+  <line x1="14" y1="21" x2="9" y2="29" stroke="#946B2D" stroke-width="1.5" stroke-linecap="round"/>
+  <!-- Tripod leg right -->
+  <line x1="14" y1="21" x2="19" y2="29" stroke="#946B2D" stroke-width="1.5" stroke-linecap="round"/>
+  <!-- Tripod crossbar -->
+  <line x1="10.5" y1="26" x2="17.5" y2="26" stroke="#946B2D" stroke-width="1" stroke-linecap="round"/>
+
+  <!-- Stars -->
+  <circle cx="25" cy="7" r="1.2" fill="#B8860B"/>
+  <circle cx="28" cy="12" r="0.8" fill="#D4A854"/>
+  <circle cx="22" cy="4" r="0.7" fill="#D4A854"/>
+</svg>

--- a/components/ActivityFeedClient.tsx
+++ b/components/ActivityFeedClient.tsx
@@ -86,9 +86,9 @@ export default function ActivityFeedClient({ members, lastFetched }: Props) {
           style={{
             padding: "0.35rem 0.85rem",
             borderRadius: 20,
-            border: "1px solid rgba(255,255,255,0.12)",
-            background: filterMember === "all" ? "rgba(255,255,255,0.12)" : "transparent",
-            color: "var(--foreground)",
+            border: "1px solid var(--border)",
+            background: filterMember === "all" ? "var(--accent-dim)" : "transparent",
+            color: filterMember === "all" ? "var(--accent)" : "var(--muted)",
             fontSize: "0.78rem",
             cursor: "pointer",
           }}
@@ -102,9 +102,9 @@ export default function ActivityFeedClient({ members, lastFetched }: Props) {
             style={{
               padding: "0.35rem 0.85rem",
               borderRadius: 20,
-              border: "1px solid rgba(255,255,255,0.12)",
-              background: filterMember === m.slug ? "rgba(255,255,255,0.12)" : "transparent",
-              color: "var(--foreground)",
+              border: "1px solid var(--border)",
+              background: filterMember === m.slug ? "var(--accent-dim)" : "transparent",
+              color: filterMember === m.slug ? "var(--accent)" : "var(--muted)",
               fontSize: "0.78rem",
               cursor: "pointer",
               display: "flex",
@@ -124,7 +124,7 @@ export default function ActivityFeedClient({ members, lastFetched }: Props) {
           </button>
         ))}
         {lastFetched && (
-          <span style={{ marginLeft: "auto", fontSize: "0.72rem", color: "rgba(255,255,255,0.3)" }}>
+          <span style={{ marginLeft: "auto", fontSize: "0.72rem", color: "var(--muted)" }}>
             Updated {timeAgo(lastFetched)}
           </span>
         )}
@@ -132,7 +132,7 @@ export default function ActivityFeedClient({ members, lastFetched }: Props) {
 
       {/* event feed */}
       {allEvents.length === 0 ? (
-        <p style={{ color: "rgba(255,255,255,0.3)", fontSize: "0.9rem" }}>No activity yet. Run the GitHub Action to populate data.</p>
+        <p style={{ color: "var(--muted)", fontSize: "0.9rem" }}>No activity yet. Run the GitHub Action to populate data.</p>
       ) : (
         <div style={{ display: "flex", flexDirection: "column", gap: 0 }}>
           {allEvents.map((e, i) => (
@@ -140,7 +140,7 @@ export default function ActivityFeedClient({ members, lastFetched }: Props) {
               display: "flex",
               gap: 14,
               padding: "12px 0",
-              borderBottom: "1px solid rgba(255,255,255,0.05)",
+              borderBottom: "1px solid var(--border)",
             }}>
               {/* avatar */}
               <div style={{
@@ -155,22 +155,22 @@ export default function ActivityFeedClient({ members, lastFetched }: Props) {
               {/* content */}
               <div style={{ flex: 1, minWidth: 0 }}>
                 <div style={{ display: "flex", alignItems: "baseline", gap: 6, flexWrap: "wrap" }}>
-                  <a href={`/team/${e.member.slug}`} style={{ fontSize: "0.82rem", fontWeight: 600, color: "var(--foreground)", textDecoration: "none" }}>
+                  <a href={`/team/${e.member.slug}`} style={{ fontSize: "0.82rem", fontWeight: 600, color: "var(--text)", textDecoration: "none" }}>
                     {e.member.name}
                   </a>
-                  <span style={{ fontSize: "0.72rem", color: "rgba(255,255,255,0.25)" }}>
+                  <span style={{ fontSize: "0.72rem", color: "var(--muted)" }}>
                     {eventIcon(e.type)}
                   </span>
-                  <a href={e.url} target="_blank" rel="noopener noreferrer" style={{ fontSize: "0.82rem", color: "rgba(255,255,255,0.7)", textDecoration: "none", minWidth: 0, overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap" }}>
+                  <a href={e.url} target="_blank" rel="noopener noreferrer" style={{ fontSize: "0.82rem", color: "var(--text-dim)", textDecoration: "none", minWidth: 0, overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap" }}>
                     {e.description}
                   </a>
                 </div>
                 <div style={{ marginTop: 3, display: "flex", alignItems: "center", gap: 8 }}>
-                  <a href={e.repoUrl} target="_blank" rel="noopener noreferrer" style={{ fontSize: "0.72rem", color: "rgba(255,255,255,0.3)", textDecoration: "none" }}>
+                  <a href={e.repoUrl} target="_blank" rel="noopener noreferrer" style={{ fontSize: "0.72rem", color: "var(--muted)", textDecoration: "none" }}>
                     {e.repo}
                   </a>
-                  <span style={{ fontSize: "0.68rem", color: "rgba(255,255,255,0.2)" }}>·</span>
-                  <span style={{ fontSize: "0.72rem", color: "rgba(255,255,255,0.25)" }}>{timeAgo(e.timestamp)}</span>
+                  <span style={{ fontSize: "0.68rem", color: "var(--border)" }}>·</span>
+                  <span style={{ fontSize: "0.72rem", color: "var(--muted)" }}>{timeAgo(e.timestamp)}</span>
                 </div>
               </div>
             </div>

--- a/components/SubscribeForm.tsx
+++ b/components/SubscribeForm.tsx
@@ -42,25 +42,25 @@ export default function SubscribeForm() {
       margin: "1.5rem auto",
       maxWidth: 560,
       padding: "1.5rem 2rem",
-      background: "rgba(255,255,255,0.03)",
-      border: "1px solid rgba(255,255,255,0.08)",
-      borderRadius: 12,
+      background: "var(--surface)",
+      border: "1px solid var(--border)",
+      borderRadius: 10,
     }}>
       <div style={{ display: "flex", alignItems: "baseline", gap: "0.75rem", marginBottom: "0.25rem" }}>
-        <p style={{ margin: 0, fontWeight: 600, fontSize: "1rem", color: "var(--foreground)" }}>
+        <p style={{ margin: 0, fontWeight: 600, fontSize: "1rem", color: "var(--text)" }}>
           Stay updated
         </p>
-        <p style={{ margin: 0, fontSize: "0.8rem", color: "rgba(255,255,255,0.35)" }}>
+        <p style={{ margin: 0, fontSize: "0.8rem", color: "var(--muted)" }}>
           Weekly digest of new news, jobs &amp; updates from AMI Labs.
         </p>
       </div>
 
       {status === "confirmed" ? (
-        <p style={{ margin: "0.75rem 0 0", color: "#4ade80", fontSize: "0.9rem" }}>
+        <p style={{ margin: "0.75rem 0 0", color: "var(--green)", fontSize: "0.9rem" }}>
           You&apos;re confirmed. You&apos;ll receive the weekly digest every Monday.
         </p>
       ) : status === "success" ? (
-        <p style={{ margin: "0.75rem 0 0", color: "#4ade80", fontSize: "0.9rem" }}>
+        <p style={{ margin: "0.75rem 0 0", color: "var(--green)", fontSize: "0.9rem" }}>
           Check your inbox for a confirmation email.
         </p>
       ) : (
@@ -76,10 +76,10 @@ export default function SubscribeForm() {
               style={{
                 flex: 1,
                 padding: "0.6rem 0.9rem",
-                background: "rgba(255,255,255,0.06)",
-                border: "1px solid rgba(255,255,255,0.12)",
-                borderRadius: 8,
-                color: "var(--foreground)",
+                background: "var(--bg)",
+                border: "1px solid var(--border)",
+                borderRadius: 6,
+                color: "var(--text)",
                 fontSize: "0.875rem",
                 outline: "none",
               }}
@@ -89,10 +89,10 @@ export default function SubscribeForm() {
               disabled={status === "loading"}
               style={{
                 padding: "0.6rem 1.2rem",
-                background: "var(--foreground)",
-                color: "var(--background)",
+                background: "var(--accent)",
+                color: "#fff",
                 border: "none",
-                borderRadius: 8,
+                borderRadius: 6,
                 fontSize: "0.875rem",
                 fontWeight: 600,
                 cursor: status === "loading" ? "not-allowed" : "pointer",
@@ -115,15 +115,15 @@ export default function SubscribeForm() {
               type="checkbox"
               checked={ftjOptIn}
               onChange={(e) => setFtjOptIn(e.target.checked)}
-              style={{ accentColor: "var(--foreground)", width: 14, height: 14, cursor: "pointer" }}
+              style={{ accentColor: "var(--accent)", width: 14, height: 14, cursor: "pointer" }}
             />
-            <span style={{ fontSize: "0.78rem", color: "rgba(255,255,255,0.45)", lineHeight: 1.4 }}>
+            <span style={{ fontSize: "0.78rem", color: "var(--text-dim)", lineHeight: 1.4 }}>
               Also subscribe to newsletters from{" "}
               <a
                 href="https://frenchtechjournal.com"
                 target="_blank"
                 rel="noopener noreferrer"
-                style={{ color: "rgba(255,255,255,0.6)", textDecoration: "underline" }}
+                style={{ color: "var(--accent2)", textDecoration: "underline" }}
               >
                 The French Tech Journal
               </a>

--- a/data/team.json
+++ b/data/team.json
@@ -136,7 +136,7 @@
     ],
     "links": {
       "linkedin": "https://www.linkedin.com/in/sainxie/",
-      "scholar": "https://scholar.google.com/citations?user=Z84yfY4AAAAJ",
+      "scholar": "https://scholar.google.com/citations?user=Y2GtJkAAAAAJ&hl=en",
       "github": "https://github.com/s9xie",
       "website": "https://www.sainingxie.com/",
       "twitter": "https://x.com/sainingxie"


### PR DESCRIPTION
- Add telescope SVG favicon (app/icon.svg) for browser tab
- Fix SubscribeForm: replace hardcoded dark rgba colors with CSS vars (text, background, border, button now use --text/--surface/--accent)
- Fix ActivityFeedClient: replace hardcoded rgba(255,255,255,...) with CSS vars so all text/borders are readable on light Observatory theme
- Fix Saining Xie's Google Scholar link to correct user ID (Y2GtJkAAAAAJ)

https://claude.ai/code/session_01Dp27HiEgrY7DAPbNMXmr5y