### PR TITLE
Add error logging to Sanity fallback catch blocks

### DIFF
--- a/app/news/page.tsx
+++ b/app/news/page.tsx
@@ -39,8 +39,8 @@ export default async function NewsPage() {
         addedAt: a.publishedAt,
       }));
     }
-  } catch {
-    // Sanity not configured yet — fall back to static JSON
+  } catch (err) {
+    console.error("[news/page] Sanity fetch failed — falling back to news.json:", err);
   }
 
   return <NewsPageClient articles={articles} />;

--- a/app/org-chart/page.tsx
+++ b/app/org-chart/page.tsx
@@ -33,7 +33,9 @@ export default async function OrgChartPage() {
         reportsTo: p.reportsTo?.slug?.current ?? null,
       }));
     }
-  } catch { /* fall back to team.json */ }
+  } catch (err) {
+    console.error("[org-chart] Sanity fetch failed — falling back to team.json:", err);
+  }
 
   return <OrgChartClient team={team} />;
 }

--- a/app/team/[slug]/page.tsx
+++ b/app/team/[slug]/page.tsx
@@ -81,7 +81,9 @@ export default async function TeamProfilePage({ params }: Props) {
         />
       );
     }
-  } catch { /* fall through to JSON */ }
+  } catch (err) {
+    console.error(`[team/${slug}] Sanity fetch failed — falling back to team.json:`, err);
+  }
 
   // Fall back to team.json
   const member = teamData.find((m) => m.slug === slug);


### PR DESCRIPTION
Silent catch blocks were hiding Sanity auth failures from Vercel logs, making it impossible to diagnose why CMS content wasn't appearing.

https://claude.ai/code/session_01Dp27HiEgrY7DAPbNMXmr5y