### PR TITLE
Fix Sanity fetch to use published perspective and exclude drafts

### DIFF
--- a/app/news/[slug]/page.tsx
+++ b/app/news/[slug]/page.tsx
@@ -131,7 +131,7 @@ const portableTextComponents = {
 
 export async function generateStaticParams() {
   try {
-    const articles: Article[] = await client.fetch(allArticlesQuery);
+    const articles: Article[] = await client.fetch(allArticlesQuery, {}, { perspective: "published" });
     return (articles ?? []).map((a) => ({ slug: a.slug.current }));
   } catch {
     return [];
@@ -141,7 +141,7 @@ export async function generateStaticParams() {
 export async function generateMetadata({ params }: { params: Promise<{ slug: string }> }): Promise<Metadata> {
   try {
     const { slug } = await params;
-    const article: Article | null = await client.fetch(articleBySlugQuery, { slug });
+    const article: Article | null = await client.fetch(articleBySlugQuery, { slug }, { perspective: "published" });
     if (!article) return {};
     return {
       title: `${article.title} — AMI Labs`,
@@ -157,7 +157,7 @@ export default async function ArticlePage({ params }: { params: Promise<{ slug: 
   let article: Article | null = null;
 
   try {
-    article = await client.fetch(articleBySlugQuery, { slug });
+    article = await client.fetch(articleBySlugQuery, { slug }, { perspective: "published" });
   } catch {
     // Sanity not reachable
   }

--- a/app/news/page.tsx
+++ b/app/news/page.tsx
@@ -26,7 +26,7 @@ export default async function NewsPage() {
   let articles = newsData as unknown as Parameters<typeof NewsPageClient>[0]["articles"];
 
   try {
-    const sanityArticles: SanityArticle[] = await client.fetch(allArticlesQuery);
+    const sanityArticles: SanityArticle[] = await client.fetch(allArticlesQuery, {}, { perspective: "published" });
     if (sanityArticles && sanityArticles.length > 0) {
       articles = sanityArticles.map((a) => ({
         id: a._id,

--- a/app/org-chart/page.tsx
+++ b/app/org-chart/page.tsx
@@ -24,7 +24,7 @@ export default async function OrgChartPage() {
     teamData.map((m) => ({ slug: m.slug, name: m.name, role: m.role, reportsTo: m.reportsTo }));
 
   try {
-    const persons: SanityPerson[] = await client.fetch(allPersonsQuery);
+    const persons: SanityPerson[] = await client.fetch(allPersonsQuery, {}, { perspective: "published" });
     if (persons?.length) {
       team = persons.map((p) => ({
         slug: p.slug.current,

--- a/app/team/[slug]/page.tsx
+++ b/app/team/[slug]/page.tsx
@@ -36,7 +36,7 @@ type SanityPerson = {
 
 export async function generateStaticParams() {
   try {
-    const persons: SanityPerson[] = await client.fetch(allPersonsQuery);
+    const persons: SanityPerson[] = await client.fetch(allPersonsQuery, {}, { perspective: "published" });
     if (persons?.length) return persons.map((p) => ({ slug: p.slug.current }));
   } catch { /* fall through */ }
   return teamData.map((m) => ({ slug: m.slug }));
@@ -45,7 +45,7 @@ export async function generateStaticParams() {
 export async function generateMetadata({ params }: Props) {
   const { slug } = await params;
   try {
-    const person: SanityPerson | null = await client.fetch(personBySlugQuery, { slug });
+    const person: SanityPerson | null = await client.fetch(personBySlugQuery, { slug }, { perspective: "published" });
     if (person) return { title: `${person.name} — AMI Labs`, description: person.body };
   } catch { /* fall through */ }
   const member = teamData.find((m) => m.slug === slug);
@@ -58,7 +58,7 @@ export default async function TeamProfilePage({ params }: Props) {
 
   // Try Sanity first
   try {
-    const person: SanityPerson | null = await client.fetch(personBySlugQuery, { slug });
+    const person: SanityPerson | null = await client.fetch(personBySlugQuery, { slug }, { perspective: "published" });
     if (person) {
       const autoPubs: Publication[] =
         (publicationsData as Record<string, Publication[]>)[slug] ?? [];

--- a/sanity/lib/queries.ts
+++ b/sanity/lib/queries.ts
@@ -3,7 +3,7 @@ import { groq } from "next-sanity";
 // ── PERSONS ─────────────────────────────────────────────────────────────────
 
 export const allPersonsQuery = groq`
-  *[_type == "person"] | order(name asc) {
+  *[_type == "person" && !(_id in path("drafts.**"))] | order(name asc) {
     _id,
     name,
     slug,
@@ -18,7 +18,7 @@ export const allPersonsQuery = groq`
 `;
 
 export const personBySlugQuery = groq`
-  *[_type == "person" && slug.current == $slug][0] {
+  *[_type == "person" && !(_id in path("drafts.**")) && slug.current == $slug][0] {
     _id,
     name,
     slug,
@@ -39,7 +39,7 @@ export const personBySlugQuery = groq`
 
 
 export const allArticlesQuery = groq`
-  *[_type == "article"] | order(publishedAt desc) {
+  *[_type == "article" && !(_id in path("drafts.**"))] | order(publishedAt desc) {
     _id,
     title,
     slug,
@@ -53,7 +53,7 @@ export const allArticlesQuery = groq`
 `;
 
 export const articleBySlugQuery = groq`
-  *[_type == "article" && slug.current == $slug][0] {
+  *[_type == "article" && !(_id in path("drafts.**")) && slug.current == $slug][0] {
     _id,
     title,
     slug,


### PR DESCRIPTION
- Add !(_id in path("drafts.**")) filter to all GROQ queries so draft documents are never returned even when fetching with a token
- Pass { perspective: "published" } to every client.fetch() call to explicitly target the published content lake, not the raw/draft state
- This resolves articles appearing in Sanity Studio but not on the site

https://claude.ai/code/session_01Dp27HiEgrY7DAPbNMXmr5y