### PR TITLE
Fix org chart to merge Sanity + static data instead of replacing

### DIFF
--- a/app/org-chart/page.tsx
+++ b/app/org-chart/page.tsx
@@ -26,12 +26,26 @@ export default async function OrgChartPage() {
   try {
     const persons: SanityPerson[] = await client.fetch(allPersonsQuery, {}, { perspective: "published" });
     if (persons?.length) {
-      team = persons.map((p) => ({
-        slug: p.slug.current,
-        name: p.name,
-        role: p.role,
-        reportsTo: p.reportsTo?.slug?.current ?? null,
-      }));
+      const sanityMap = new Map(
+        persons.map((p) => [p.slug.current, {
+          slug: p.slug.current,
+          name: p.name,
+          role: p.role,
+          reportsTo: p.reportsTo?.slug?.current ?? null,
+        }])
+      );
+      // Override static entries with Sanity data where a match exists, add new Sanity-only entries
+      team = [
+        ...team.map((m) => sanityMap.get(m.slug) ?? m),
+        ...persons
+          .filter((p) => !team.some((m) => m.slug === p.slug.current))
+          .map((p) => ({
+            slug: p.slug.current,
+            name: p.name,
+            role: p.role,
+            reportsTo: p.reportsTo?.slug?.current ?? null,
+          })),
+      ];
     }
   } catch (err) {
     console.error("[org-chart] Sanity fetch failed — falling back to team.json:", err);


### PR DESCRIPTION
When Sanity returns persons, the org chart was replacing the entire team.json dataset with only CMS entries. Now it merges: static entries are overridden by their Sanity counterpart if one exists, and new Sanity-only entries are appended. team.json remains the baseline.

https://claude.ai/code/session_01Y4dJUrrCCmZQoP2zM7uUAc