### PR TITLE
Fix buildTree to not overwrite root with subsequent null-reportsTo nodes

### DIFF
--- a/components/OrgChartClient.tsx
+++ b/components/OrgChartClient.tsx
@@ -22,14 +22,29 @@ function buildTree(team: Member[]): TreeNode {
   team.forEach((m) => map.set(m.slug, { slug: m.slug, name: m.name, role: m.role, children: [] }));
 
   let root: TreeNode | null = null;
+  const orphans: TreeNode[] = [];
+
   team.forEach((m) => {
     if (!m.reportsTo) {
-      root = map.get(m.slug)!;
+      if (!root) {
+        root = map.get(m.slug)!; // first null-reportsTo wins as root
+      } else {
+        orphans.push(map.get(m.slug)!); // subsequent rootless nodes queued
+      }
     } else {
       const parent = map.get(m.reportsTo);
-      if (parent) parent.children = [...(parent.children || []), map.get(m.slug)!];
+      if (parent) {
+        parent.children = [...(parent.children || []), map.get(m.slug)!];
+      } else {
+        orphans.push(map.get(m.slug)!); // reportsTo slug not found in chart
+      }
     }
   });
+
+  // Attach orphans directly to root so they appear rather than breaking the tree
+  if (root && orphans.length) {
+    root.children = [...(root.children || []), ...orphans];
+  }
 
   // Clean up empty children arrays
   map.forEach((node) => { if (!node.children?.length) delete node.children; });


### PR DESCRIPTION
buildTree was assigning root to every member with reportsTo=null, so the last one processed always won. David Fan (added via Sanity without a reportsTo) was appended last, making him root and orphaning the entire existing tree.

Now only the first null-reportsTo member becomes root. Any subsequent rootless or unresolvable-parent nodes are attached to root as fallbacks so they still appear in the chart without breaking the hierarchy.

https://claude.ai/code/session_01Y4dJUrrCCmZQoP2zM7uUAc