### PR TITLE
Fix TypeScript never error in buildTree orphan attachment

### DIFF
--- a/components/OrgChartClient.tsx
+++ b/components/OrgChartClient.tsx
@@ -42,14 +42,15 @@ function buildTree(team: Member[]): TreeNode {
   });
 
   // Attach orphans directly to root so they appear rather than breaking the tree
-  if (root && orphans.length) {
-    root.children = [...(root.children || []), ...orphans];
+  const finalRoot = root;
+  if (finalRoot && orphans.length) {
+    finalRoot.children = [...(finalRoot.children || []), ...orphans];
   }
 
   // Clean up empty children arrays
   map.forEach((node) => { if (!node.children?.length) delete node.children; });
 
-  return root!;
+  return finalRoot!;
 }
 
 const AVATAR_COLORS = [


### PR DESCRIPTION
TypeScript loses track of the root variable type after forEach callbacks, narrowing it to never. Copy to a const before the conditional so the compiler can correctly narrow to TreeNode.

https://claude.ai/code/session_01Y4dJUrrCCmZQoP2zM7uUAc