### PR TITLE
Fix TypeScript never error by replacing forEach with for...of in buil…

### DIFF
--- a/components/OrgChartClient.tsx
+++ b/components/OrgChartClient.tsx
@@ -24,7 +24,7 @@ function buildTree(team: Member[]): TreeNode {
   let root: TreeNode | null = null;
   const orphans: TreeNode[] = [];
 
-  team.forEach((m) => {
+  for (const m of team) {
     if (!m.reportsTo) {
       if (!root) {
         root = map.get(m.slug)!; // first null-reportsTo wins as root
@@ -39,18 +39,19 @@ function buildTree(team: Member[]): TreeNode {
         orphans.push(map.get(m.slug)!); // reportsTo slug not found in chart
       }
     }
-  });
+  }
 
   // Attach orphans directly to root so they appear rather than breaking the tree
-  const finalRoot = root;
-  if (finalRoot && orphans.length) {
-    finalRoot.children = [...(finalRoot.children || []), ...orphans];
+  if (root && orphans.length) {
+    root.children = [...(root.children || []), ...orphans];
   }
 
   // Clean up empty children arrays
-  map.forEach((node) => { if (!node.children?.length) delete node.children; });
+  for (const node of map.values()) {
+    if (!node.children?.length) delete node.children;
+  }
 
-  return finalRoot!;
+  return root!;
 }
 
 const AVATAR_COLORS = [


### PR DESCRIPTION
…dTree

TypeScript's control flow analysis doesn't track variable assignments made inside forEach callbacks, so it sees root as still null after the loop and narrows it to never inside the if block. Switching to for...of gives the compiler proper control flow visibility.

https://claude.ai/code/session_01Y4dJUrrCCmZQoP2zM7uUAc