### PR TITLE
Change profile back link to go to org chart

### DIFF
--- a/components/ProfileClient.tsx
+++ b/components/ProfileClient.tsx
@@ -154,8 +154,8 @@ export default function ProfileClient({
       </div>
 
       <div className="profile-content">
-        <Link href="/" className="back-link">
-          ← Back to Explorer
+        <Link href="/org-chart" className="back-link">
+          ← Back to Org Chart
         </Link>
 
         {/* BIOGRAPHY */}


### PR DESCRIPTION
The back link on team profile pages now points to /org-chart with the label "Back to Org Chart", since profiles are navigated to from there.

https://claude.ai/code/session_01Y4dJUrrCCmZQoP2zM7uUAc