### PR TITLE
Add three new researchers to team directory

### DIFF
--- a/data/team.json
+++ b/data/team.json
@@ -436,5 +436,47 @@
       "linkedin": "https://www.linkedin.com/in/sean-nguyen-74350b26/"
     },
     "semanticScholarId": null
+  },
+  {
+    "slug": "david-fan",
+    "name": "David Fan",
+    "role": "Researcher",
+    "body": "",
+    "tags": [],
+    "reportsTo": null,
+    "biography": null,
+    "careerHistory": [],
+    "links": {
+      "github": "https://github.com/dfan"
+    },
+    "semanticScholarId": null
+  },
+  {
+    "slug": "xinyi-wan",
+    "name": "Xinyi Wan",
+    "role": "Researcher",
+    "body": "",
+    "tags": [],
+    "reportsTo": null,
+    "biography": null,
+    "careerHistory": [],
+    "links": {
+      "github": "https://github.com/ufotalent"
+    },
+    "semanticScholarId": null
+  },
+  {
+    "slug": "jihan-yang",
+    "name": "Jihan Yang",
+    "role": "Researcher",
+    "body": "",
+    "tags": [],
+    "reportsTo": null,
+    "biography": null,
+    "careerHistory": [],
+    "links": {
+      "github": "https://github.com/jihanyang"
+    },
+    "semanticScholarId": null
   }
 ]


### PR DESCRIPTION
## Summary
This PR adds three new team members to the team directory by updating the `data/team.json` file with their profiles.

## Key Changes
- Added David Fan (Researcher) with GitHub profile: https://github.com/dfan
- Added Xinyi Wan (Researcher) with GitHub profile: https://github.com/ufotalent
- Added Jihan Yang (Researcher) with GitHub profile: https://github.com/jihanyang

## Implementation Details
Each new team member entry includes:
- Unique slug identifier for URL/reference purposes
- Full name and role designation as "Researcher"
- GitHub profile link in the links section
- Standard fields (biography, careerHistory, tags, reportsTo) initialized as empty/null for future population

https://claude.ai/code/session_01Lwu1HZpx1euy9dy9R3pcGT