### PR TITLE
Fix digest query to use publishedAt instead of _createdAt

### DIFF
--- a/scripts/send-digest.js
+++ b/scripts/send-digest.js
@@ -91,7 +91,7 @@ async function fetchSanityArticles() {
   }
   try {
     const query = encodeURIComponent(
-      `*[_type == "article" && !(_id in path("drafts.**")) && _createdAt >= "${cutoff.toISOString()}"] | order(_createdAt desc) { title, slug, source, externalUrl, publishedAt, summary }`
+      `*[_type == "article" && !(_id in path("drafts.**")) && publishedAt >= "${cutoff.toISOString()}"] | order(publishedAt desc) { title, slug, source, externalUrl, publishedAt, summary }`
     );
     const url = `https://${SANITY_PROJECT_ID}.api.sanity.io/v2024-01-01/data/query/${SANITY_DATASET}?query=${query}`;
     const res = await get(url, {


### PR DESCRIPTION
## Summary
Updated the Sanity article query in the digest script to filter and sort articles by `publishedAt` instead of `_createdAt`. This ensures the digest includes articles based on their publication date rather than when they were created in the system.

## Changes
- Modified the GROQ query filter condition from `_createdAt >= "${cutoff.toISOString()}"` to `publishedAt >= "${cutoff.toISOString()}"`
- Updated the sort order from `order(_createdAt desc)` to `order(publishedAt desc)`

## Details
This change aligns the digest generation logic with the actual publication timeline of articles. Using `publishedAt` is more semantically correct for a digest feature, as it reflects when content was made public rather than when it was initially drafted or created in the CMS.

https://claude.ai/code/session_01D3mrEEDt94yNJSmyLP2u2J