### PR TITLE
fix: filter news.json by status field on news and homepage

### DIFF
--- a/app/news/page.tsx
+++ b/app/news/page.tsx
@@ -23,7 +23,10 @@ type SanityArticle = {
 };
 
 export default async function NewsPage() {
-  const jsonArticles = newsData as unknown as Parameters<typeof NewsPageClient>[0]["articles"];
+  // Filter news.json: only show approved articles and legacy articles (no status field).
+  // Pending/rejected articles are hidden until approved via /admin/review.
+  const jsonArticles = (newsData as unknown as (Parameters<typeof NewsPageClient>[0]["articles"][number] & { status?: string })[])
+    .filter((a) => !a.status || a.status === "approved");
 
   let sanityArticles: Parameters<typeof NewsPageClient>[0]["articles"] = [];
 

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -18,14 +18,16 @@ type SanityArticle = {
 };
 
 export default async function Home() {
-  const jsonArticles = newsData as unknown as {
+  // Filter news.json: only show approved articles and legacy articles (no status field).
+  const jsonArticles = (newsData as unknown as {
     id: string;
     title: string;
     source: string;
     url: string;
     publishedAt: string;
     tags: string[];
-  }[];
+    status?: string;
+  }[]).filter((a) => !a.status || a.status === "approved");
 
   let sanityArticles: typeof jsonArticles = [];
 


### PR DESCRIPTION
Bug: articles with reviewStatus=pending in Sanity were correctly filtered out by the Sanity query, but the news.json fallback merge was not filtering by status. So pending articles written to both Sanity and news.json slipped through via the JSON path.

Fix: filter news.json to only include articles where status is undefined (legacy articles) or "approved". This ensures pending and rejected articles stay hidden until approved via /admin/review.

https://claude.ai/code/session_012PDqzBhK1oSCLLaAVWHhRz