### PR TITLE
feat: add team grid page and warm up org chart palette

### DIFF
--- a/app/team/page.tsx
+++ b/app/team/page.tsx
@@ -1,0 +1,77 @@
+import teamData from "@/data/team.json";
+import TeamGridClient from "@/components/TeamGridClient";
+import { client } from "@/sanity/lib/client";
+import { allPersonsQuery } from "@/sanity/lib/queries";
+import type { Metadata } from "next";
+
+export const revalidate = 300;
+
+export const metadata: Metadata = {
+  title: "Team — AMI Labs Intelligence Hub",
+  description: "Meet the AMI Labs team — founders, researchers, and engineers building advanced machine intelligence.",
+};
+
+type SanityPerson = {
+  _id: string;
+  name: string;
+  slug: { current: string };
+  role: string;
+  body?: string;
+  tags?: string[];
+  reportsTo?: { slug: { current: string } } | null;
+  photo?: { asset: Record<string, unknown>; alt?: string | null } | null;
+  links?: Record<string, string | undefined>;
+};
+
+export type TeamMember = {
+  slug: string;
+  name: string;
+  role: string;
+  body: string;
+  tags: string[];
+  links: Record<string, string | undefined>;
+};
+
+export default async function TeamPage() {
+  let team: TeamMember[] = teamData.map((m) => ({
+    slug: m.slug,
+    name: m.name,
+    role: m.role,
+    body: m.body || "",
+    tags: m.tags || [],
+    links: m.links || {},
+  }));
+
+  try {
+    const persons: SanityPerson[] = await client.fetch(allPersonsQuery, {}, { perspective: "published" });
+    if (persons?.length) {
+      const sanityMap = new Map(
+        persons.map((p) => [p.slug.current, {
+          slug: p.slug.current,
+          name: p.name,
+          role: p.role,
+          body: typeof p.body === "string" ? p.body : "",
+          tags: p.tags ?? [],
+          links: p.links ?? {},
+        }])
+      );
+      team = [
+        ...team.map((m) => sanityMap.get(m.slug) ?? m),
+        ...persons
+          .filter((p) => !team.some((m) => m.slug === p.slug.current))
+          .map((p) => ({
+            slug: p.slug.current,
+            name: p.name,
+            role: p.role,
+            body: typeof p.body === "string" ? p.body : "",
+            tags: p.tags ?? [],
+            links: p.links ?? {},
+          })),
+      ];
+    }
+  } catch (err) {
+    console.error("[team] Sanity fetch failed — falling back to team.json:", err);
+  }
+
+  return <TeamGridClient team={team} />;
+}

--- a/components/Nav.tsx
+++ b/components/Nav.tsx
@@ -7,7 +7,8 @@ const links = [
   { href: "/explainers", label: "Explainers" },
   { href: "/timeline", label: "Timeline" },
   { href: "/investors", label: "Investors" },
-  { href: "/org-chart", label: "Team" },
+  { href: "/team", label: "Team" },
+  { href: "/org-chart", label: "Org Chart" },
   { href: "/activity", label: "Activity" },
   { href: "/docs", label: "Docs" },
 ];

--- a/components/OrgChartClient.tsx
+++ b/components/OrgChartClient.tsx
@@ -53,9 +53,9 @@ function buildTree(team: Member[]): TreeNode {
 }
 
 const AVATAR_COLORS = [
-  ["#6c63ff", "#a78bfa"], ["#3b82f6", "#60a5fa"], ["#10b981", "#34d399"],
-  ["#f59e0b", "#fbbf24"], ["#ef4444", "#f87171"], ["#8b5cf6", "#c084fc"],
-  ["#ec4899", "#f472b6"], ["#14b8a6", "#2dd4bf"],
+  ["#946B2D", "#B8960B"], ["#2A7D6B", "#3D9E88"], ["#3D7A4A", "#5EA06A"],
+  ["#C07A3A", "#D99B5C"], ["#A85C72", "#C8849A"], ["#7B5EA7", "#9D84C4"],
+  ["#4A7FA5", "#6FA3C4"], ["#5C8A5E", "#7FAE82"],
 ];
 
 function getColor(name: string) {
@@ -124,7 +124,7 @@ export default function OrgChartClient({ team }: { team: Member[] }) {
       .enter()
       .append("path")
       .attr("fill", "none")
-      .attr("stroke", "#2a2a3a")
+      .attr("stroke", "var(--border)")
       .attr("stroke-width", 1.5)
       .attr("d", (d) => {
         const sx = d.source.x ?? 0, sy = (d.source.y ?? 0) + nodeH / 2;
@@ -155,7 +155,7 @@ export default function OrgChartClient({ team }: { team: Member[] }) {
       .style("cursor", "pointer")
       .on("click", (_, d) => router.push(`/team/${d.data.slug}`))
       .on("mouseenter", function (event: MouseEvent, d) {
-        d3.select(this).select("rect").attr("stroke", "#6c63ff");
+        d3.select(this).select("rect").attr("stroke", "var(--accent)");
         setTooltip({
           name: d.data.name,
           role: d.data.role,
@@ -165,7 +165,7 @@ export default function OrgChartClient({ team }: { team: Member[] }) {
         });
       })
       .on("mouseleave", function () {
-        d3.select(this).select("rect").attr("stroke", "#2a2a3a");
+        d3.select(this).select("rect").attr("stroke", "var(--border)");
         setTooltip(null);
       });
 
@@ -173,8 +173,8 @@ export default function OrgChartClient({ team }: { team: Member[] }) {
       .attr("width", nodeW)
       .attr("height", nodeH)
       .attr("rx", 12)
-      .attr("fill", "#13131a")
-      .attr("stroke", "#2a2a3a")
+      .attr("fill", "var(--surface)")
+      .attr("stroke", "var(--border)")
       .attr("stroke-width", 1);
 
     // Avatar circle
@@ -198,7 +198,7 @@ export default function OrgChartClient({ team }: { team: Member[] }) {
     nodeGroup.append("text")
       .attr("x", 68)
       .attr("y", nodeH / 2 - 10)
-      .attr("fill", "#e2e2f0")
+      .attr("fill", "var(--text)")
       .attr("font-size", "13px")
       .attr("font-weight", "600")
       .attr("font-family", "-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif")
@@ -208,7 +208,7 @@ export default function OrgChartClient({ team }: { team: Member[] }) {
     nodeGroup.append("text")
       .attr("x", 68)
       .attr("y", nodeH / 2 + 10)
-      .attr("fill", "#8888aa")
+      .attr("fill", "var(--muted)")
       .attr("font-size", "11px")
       .attr("font-family", "-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif")
       .text((d) => d.data.role.length > 26 ? d.data.role.slice(0, 25) + "…" : d.data.role);
@@ -223,7 +223,7 @@ export default function OrgChartClient({ team }: { team: Member[] }) {
     top: Math.min(tooltip.y - 20, (typeof window !== "undefined" ? window.innerHeight : 800) - TOOLTIP_H - 8),
   } : null;
 
-  const tooltipColors = tooltip ? getColor(tooltip.name) : ["#6c63ff", "#a78bfa"];
+  const tooltipColors = tooltip ? getColor(tooltip.name) : ["#946B2D", "#B8960B"];
 
   return (
     <>
@@ -260,11 +260,11 @@ export default function OrgChartClient({ team }: { team: Member[] }) {
             width: TOOLTIP_W,
             zIndex: 1000,
             pointerEvents: "none",
-            background: "#1a1a2e",
-            border: "1px solid #6c63ff",
+            background: "var(--bg)",
+            border: "1px solid var(--accent)",
             borderRadius: "14px",
             padding: "16px 20px",
-            boxShadow: "0 8px 32px rgba(108,99,255,0.25), 0 2px 8px rgba(0,0,0,0.5)",
+            boxShadow: "0 8px 32px rgba(148, 107, 45, 0.15), 0 2px 8px rgba(0,0,0,0.08)",
             display: "flex",
             alignItems: "center",
             gap: "16px",
@@ -292,7 +292,7 @@ export default function OrgChartClient({ team }: { team: Member[] }) {
           {/* Text */}
           <div style={{ minWidth: 0 }}>
             <div style={{
-              color: "#e2e2f0",
+              color: "var(--text)",
               fontSize: "15px",
               fontWeight: 700,
               lineHeight: 1.3,
@@ -301,7 +301,7 @@ export default function OrgChartClient({ team }: { team: Member[] }) {
               {tooltip.name}
             </div>
             <div style={{
-              color: "#8888aa",
+              color: "var(--muted)",
               fontSize: "12px",
               lineHeight: 1.4,
               marginBottom: "8px",
@@ -309,7 +309,7 @@ export default function OrgChartClient({ team }: { team: Member[] }) {
               {tooltip.role}
             </div>
             <div style={{
-              color: "#6c63ff",
+              color: "var(--accent)",
               fontSize: "11px",
               fontWeight: 500,
             }}>

--- a/components/TeamGridClient.tsx
+++ b/components/TeamGridClient.tsx
@@ -1,0 +1,220 @@
+"use client";
+import Link from "next/link";
+
+type TeamMember = {
+  slug: string;
+  name: string;
+  role: string;
+  body: string;
+  tags: string[];
+  links: Record<string, string | undefined>;
+};
+
+const GROUPS: { label: string; test: (role: string) => boolean }[] = [
+  { label: "Leadership", test: (r) => /chairman|ceo|coo/i.test(r) },
+  { label: "Science & Research Leadership", test: (r) => /chief|^vp |vice president/i.test(r) },
+  { label: "Operations", test: (r) => /director|operations/i.test(r) },
+];
+
+function getGroup(role: string): string {
+  for (const g of GROUPS) {
+    if (g.test(role)) return g.label;
+  }
+  return "Research & Engineering";
+}
+
+const GROUP_ORDER = ["Leadership", "Science & Research Leadership", "Research & Engineering", "Operations"];
+
+const AVATAR_COLORS: [string, string][] = [
+  ["#946B2D", "#B8960B"],
+  ["#2A7D6B", "#3D9E88"],
+  ["#3D7A4A", "#5EA06A"],
+  ["#A85C72", "#C8849A"],
+  ["#4A7FA5", "#6FA3C4"],
+  ["#C07A3A", "#D99B5C"],
+  ["#7B5EA7", "#9D84C4"],
+  ["#5C8A5E", "#7FAE82"],
+];
+
+function getColor(name: string): [string, string] {
+  return AVATAR_COLORS[name.charCodeAt(0) % AVATAR_COLORS.length];
+}
+
+function initials(name: string) {
+  return name.split(/\s+/).map((w) => w[0]).join("").slice(0, 2).toUpperCase();
+}
+
+const LINK_ICONS: Record<string, string> = {
+  linkedin: "in",
+  twitter: "𝕏",
+  scholar: "S",
+  github: "G",
+  website: "↗",
+};
+
+function LinkIcon({ type, url }: { type: string; url: string }) {
+  return (
+    <a
+      href={url}
+      target="_blank"
+      rel="noopener noreferrer"
+      title={type}
+      style={{
+        display: "inline-flex", alignItems: "center", justifyContent: "center",
+        width: 26, height: 26, borderRadius: 6,
+        background: "var(--surface2)", color: "var(--muted)",
+        fontSize: 11, fontWeight: 700, textDecoration: "none",
+        transition: "all 0.15s",
+      }}
+      onMouseEnter={(e) => {
+        e.currentTarget.style.background = "var(--accent-dim)";
+        e.currentTarget.style.color = "var(--accent)";
+      }}
+      onMouseLeave={(e) => {
+        e.currentTarget.style.background = "var(--surface2)";
+        e.currentTarget.style.color = "var(--muted)";
+      }}
+    >
+      {LINK_ICONS[type] || "↗"}
+    </a>
+  );
+}
+
+export default function TeamGridClient({ team }: { team: TeamMember[] }) {
+  const grouped = new Map<string, TeamMember[]>();
+  for (const label of GROUP_ORDER) grouped.set(label, []);
+  for (const m of team) {
+    const g = getGroup(m.role);
+    if (!grouped.has(g)) grouped.set(g, []);
+    grouped.get(g)!.push(m);
+  }
+
+  return (
+    <>
+      <div className="page-header">
+        <div className="page-header-inner">
+          <h1>Team</h1>
+          <p>
+            {team.length} members across Paris, New York, Montreal, and Singapore.{" "}
+            <Link href="/org-chart" style={{ color: "var(--accent)", textDecoration: "underline", textDecorationColor: "var(--border)" }}>
+              View org chart →
+            </Link>
+          </p>
+        </div>
+      </div>
+      <main>
+        {GROUP_ORDER.filter((label) => (grouped.get(label)?.length ?? 0) > 0).map((label) => (
+          <section key={label} style={{ marginBottom: 48 }}>
+            <h2 style={{
+              fontFamily: "var(--font-serif)", fontSize: 20, fontWeight: 600,
+              color: "var(--accent)", marginBottom: 20,
+              paddingBottom: 8, borderBottom: "1px solid var(--border)",
+            }}>
+              {label}
+            </h2>
+            <div style={{
+              display: "grid",
+              gridTemplateColumns: "repeat(auto-fill, minmax(280px, 1fr))",
+              gap: 20,
+            }}>
+              {grouped.get(label)!.map((m) => {
+                const [c1, c2] = getColor(m.name);
+                const linkEntries = Object.entries(m.links).filter(
+                  ([k, v]) => v && LINK_ICONS[k]
+                ) as [string, string][];
+
+                return (
+                  <Link
+                    key={m.slug}
+                    href={`/team/${m.slug}`}
+                    style={{ textDecoration: "none", color: "inherit" }}
+                  >
+                    <div
+                      style={{
+                        background: "var(--surface)", border: "1px solid var(--border)",
+                        borderRadius: 10, padding: 24,
+                        transition: "border-color 0.15s, box-shadow 0.15s",
+                        cursor: "pointer", height: "100%",
+                        display: "flex", flexDirection: "column",
+                      }}
+                      onMouseEnter={(e) => {
+                        e.currentTarget.style.borderColor = "var(--accent)";
+                        e.currentTarget.style.boxShadow = "0 2px 12px rgba(148, 107, 45, 0.1)";
+                      }}
+                      onMouseLeave={(e) => {
+                        e.currentTarget.style.borderColor = "var(--border)";
+                        e.currentTarget.style.boxShadow = "none";
+                      }}
+                    >
+                      {/* Header: avatar + name/role */}
+                      <div style={{ display: "flex", alignItems: "center", gap: 16, marginBottom: 12 }}>
+                        <div style={{
+                          width: 52, height: 52, borderRadius: "50%", flexShrink: 0,
+                          background: `linear-gradient(135deg, ${c1}, ${c2})`,
+                          display: "flex", alignItems: "center", justifyContent: "center",
+                          fontSize: 18, fontWeight: 700, color: "#fff", letterSpacing: "0.02em",
+                        }}>
+                          {initials(m.name)}
+                        </div>
+                        <div style={{ minWidth: 0 }}>
+                          <div style={{
+                            fontSize: 16, fontWeight: 700, color: "var(--text)",
+                            lineHeight: 1.3, marginBottom: 2,
+                          }}>
+                            {m.name}
+                          </div>
+                          <div style={{
+                            fontSize: 13, color: "var(--text-dim)", lineHeight: 1.3,
+                          }}>
+                            {m.role}
+                          </div>
+                        </div>
+                      </div>
+
+                      {/* Tags */}
+                      {m.tags.length > 0 && (
+                        <div style={{ display: "flex", gap: 6, flexWrap: "wrap", marginBottom: 10 }}>
+                          {m.tags.map((tag) => (
+                            <span key={tag} style={{
+                              fontSize: 11, padding: "2px 8px", borderRadius: 4,
+                              background: "var(--accent-dim)", color: "var(--accent)",
+                              border: "1px solid var(--border)", fontWeight: 500,
+                            }}>
+                              {tag}
+                            </span>
+                          ))}
+                        </div>
+                      )}
+
+                      {/* Body */}
+                      {m.body && (
+                        <p style={{
+                          fontSize: 13, color: "var(--muted)", lineHeight: 1.55,
+                          flex: 1,
+                        }}>
+                          {m.body.length > 140 ? m.body.slice(0, 137) + "…" : m.body}
+                        </p>
+                      )}
+
+                      {/* Links */}
+                      {linkEntries.length > 0 && (
+                        <div
+                          style={{ display: "flex", gap: 6, marginTop: 12 }}
+                          onClick={(e) => e.stopPropagation()}
+                        >
+                          {linkEntries.map(([type, url]) => (
+                            <LinkIcon key={type} type={type} url={url} />
+                          ))}
+                        </div>
+                      )}
+                    </div>
+                  </Link>
+                );
+              })}
+            </div>
+          </section>
+        ))}
+      </main>
+    </>
+  );
+}


### PR DESCRIPTION
New /team page with responsive grid of profile cards (280px min width) grouped by function: Leadership, Science & Research Leadership, Research & Engineering, Operations. Each card shows avatar, name, role, location tags, bio snippet, and social links. Cards link to the existing /team/[slug] profile pages.

Updated org chart to use warm Observatory palette (--surface, --border, --text, --accent) instead of the dark theme colors (#13131a, #2a2a3a, #6c63ff). Tooltip also themed warm.

Nav updated: "Team" now links to /team grid, "Org Chart" added as a separate nav entry. Team page header links to org chart view.

https://claude.ai/code/session_012PDqzBhK1oSCLLaAVWHhRz