### PR TITLE
Redesign org chart per design handoff

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -2455,3 +2455,405 @@ input[type="search"]::placeholder { color: var(--muted); }
     width: 100%;
   }
 }
+
+/* ============================================================
+   ORG CHART — Observatory redesign
+   Namespaced (.pcard, .org-*, .ph-*, .legend) — additive only.
+   ============================================================ */
+
+/* Extended page header used on /org-chart */
+.page-header--observatory {
+  padding: 44px 40px 36px;
+  position: relative;
+  overflow: hidden;
+}
+.page-header--observatory::before {
+  content: "";
+  position: absolute; inset: 0;
+  background:
+    radial-gradient(ellipse 600px 200px at 85% 0%, rgba(200, 150, 46, 0.10), transparent 70%),
+    radial-gradient(ellipse 500px 200px at 10% 100%, rgba(42, 125, 107, 0.06), transparent 70%);
+  pointer-events: none;
+}
+.page-header--observatory .page-header-inner { position: relative; }
+.page-header--observatory h1 {
+  font-family: var(--font-serif);
+  font-size: 2.5rem;
+  font-weight: 500;
+  letter-spacing: -0.02em;
+  line-height: 1.1;
+  color: var(--text);
+  margin-bottom: 10px;
+  max-width: 780px;
+}
+.page-header--observatory p {
+  color: var(--text-dim);
+  font-size: 1rem;
+  max-width: 620px;
+  line-height: 1.55;
+}
+
+.ph-eyebrow {
+  display: inline-flex; align-items: center; gap: 8px;
+  font-size: 0.72rem; color: var(--accent);
+  letter-spacing: 0.12em; text-transform: uppercase; font-weight: 600;
+  margin-bottom: 12px;
+}
+.ph-dot {
+  width: 6px; height: 6px; border-radius: 50%;
+  background: var(--accent2);
+  animation: amiPulse 2.4s ease-in-out infinite;
+}
+@keyframes amiPulse {
+  0%, 100% { opacity: 0.45; transform: scale(1); }
+  50%      { opacity: 1;    transform: scale(1.25); }
+}
+
+.ph-stats {
+  display: flex; gap: 44px; margin-top: 28px; flex-wrap: wrap;
+}
+.ph-stat {
+  border-left: 2px solid var(--accent3);
+  padding-left: 14px;
+}
+.ph-stat-num {
+  font-family: var(--font-serif);
+  font-size: 1.55rem; font-weight: 500;
+  color: var(--text); letter-spacing: -0.02em;
+}
+.ph-stat--update .ph-stat-num { font-size: 1.15rem; }
+.ph-stat-label {
+  font-size: 0.7rem; color: var(--muted);
+  letter-spacing: 0.1em; text-transform: uppercase; font-weight: 600;
+  margin-top: 2px;
+}
+
+/* ── ORG CONTROLS (sticky search + legend) ── */
+.org-controls {
+  background: var(--bg);
+  border-bottom: 1px solid var(--border);
+  padding: 0 40px;
+  position: sticky; top: 63px; z-index: 90;
+}
+.org-controls-inner {
+  max-width: 1400px; margin: 0 auto;
+  display: flex; gap: 24px; align-items: center;
+  min-height: 56px; flex-wrap: wrap;
+}
+.org-search {
+  position: relative; width: 340px;
+}
+.org-search svg {
+  position: absolute; left: 12px; top: 50%;
+  transform: translateY(-50%); color: var(--muted);
+  pointer-events: none;
+}
+.org-search input {
+  width: 100%;
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  color: var(--text);
+  font-family: inherit; font-size: 0.88rem;
+  padding: 8px 14px 8px 38px;
+  outline: none;
+  transition: border-color 0.2s, box-shadow 0.2s, background 0.2s;
+}
+.org-search input:focus {
+  border-color: var(--accent2);
+  background: var(--bg);
+  box-shadow: 0 0 0 3px var(--accent-dim);
+}
+.org-search input::placeholder { color: var(--muted); }
+
+.legend {
+  margin-left: auto;
+  display: flex; gap: 18px; flex-wrap: wrap;
+}
+.legend-dot {
+  display: inline-flex; align-items: center; gap: 7px;
+  font-size: 0.75rem; color: var(--text-dim); font-weight: 500;
+  letter-spacing: 0.01em;
+}
+.legend-swatch {
+  width: 8px; height: 8px; border-radius: 50%;
+}
+
+/* ── ORG MAIN / CANVAS ── */
+.org-main {
+  padding: 36px 40px 56px;
+}
+.org-canvas-wrap {
+  max-width: 1400px; margin: 0 auto;
+  background:
+    linear-gradient(var(--surface), var(--surface)) padding-box,
+    linear-gradient(135deg, rgba(200, 150, 46, 0.22), rgba(42, 125, 107, 0.10) 50%, rgba(168, 92, 114, 0.15)) border-box;
+  border: 1px solid transparent;
+  border-radius: 12px;
+  padding: 12px;
+  overflow: auto;
+  box-shadow:
+    0 1px 2px rgba(44, 37, 23, 0.04),
+    0 12px 32px rgba(44, 37, 23, 0.06);
+  position: relative;
+}
+.org-canvas-wrap::before {
+  content: "";
+  position: absolute; inset: 12px; pointer-events: none;
+  border-radius: 8px;
+  background-image:
+    radial-gradient(circle at 20% 15%, rgba(200, 150, 46, 0.06), transparent 40%),
+    radial-gradient(circle at 80% 80%, rgba(42, 125, 107, 0.04), transparent 40%);
+}
+.org-canvas {
+  position: relative;
+  background:
+    radial-gradient(circle at 1px 1px, rgba(148, 107, 45, 0.10) 1px, transparent 0) 0 0 / 24px 24px,
+    var(--bg);
+  border-radius: 8px;
+  margin: 0 auto;
+}
+.org-footnote {
+  max-width: 1400px; margin: 18px auto 0;
+  text-align: center;
+  color: var(--muted);
+  font-size: 0.78rem;
+  font-style: italic;
+  font-family: var(--font-serif);
+}
+
+/* ── CONNECTORS ── */
+.org-connectors {
+  position: absolute; inset: 0;
+  pointer-events: none;
+}
+.org-link {
+  stroke: #BFB49D;
+  stroke-width: 1.4;
+  stroke-linecap: round;
+  fill: none;
+  opacity: 0.85;
+  transition: stroke 0.4s, stroke-width 0.4s, opacity 0.4s;
+  stroke-dasharray: 2000;
+  stroke-dashoffset: 2000;
+  animation: orgDrawLine 900ms cubic-bezier(0.4, 0, 0.2, 1) forwards;
+}
+@keyframes orgDrawLine {
+  to { stroke-dashoffset: 0; }
+}
+.org-link--dim   { opacity: 0.25; }
+.org-link--focus {
+  stroke: var(--accent2);
+  stroke-width: 2.2;
+  opacity: 1;
+}
+
+/* ── NODES ── */
+.org-node {
+  position: absolute;
+  opacity: 0;
+  transform: translateY(8px);
+  animation: orgNodeIn 520ms cubic-bezier(0.22, 1, 0.36, 1) forwards;
+}
+@keyframes orgNodeIn {
+  to { opacity: 1; transform: translateY(0); }
+}
+
+/* ── PERSON CARD ── */
+.pcard {
+  position: relative;
+  width: 100%;
+  background: var(--bg);
+  border: 1px solid var(--border);
+  border-radius: 10px;
+  padding: 16px 18px 14px;
+  box-shadow:
+    0 1px 2px rgba(44, 37, 23, 0.04),
+    0 2px 8px rgba(44, 37, 23, 0.03);
+  cursor: pointer;
+  transition:
+    transform 280ms cubic-bezier(0.22, 1, 0.36, 1),
+    box-shadow 280ms ease,
+    border-color 220ms ease,
+    opacity 240ms ease,
+    filter 240ms ease;
+  overflow: hidden;
+  will-change: transform;
+}
+.pcard::after {
+  content: "";
+  position: absolute; inset: 0;
+  background: linear-gradient(135deg, rgba(255, 252, 245, 0) 60%, rgba(200, 150, 46, 0.06) 100%);
+  opacity: 0;
+  transition: opacity 260ms ease;
+  pointer-events: none;
+}
+.pcard:hover {
+  border-color: var(--tile-a, var(--accent2));
+  transform: translateY(-3px);
+  box-shadow:
+    0 2px 4px rgba(44, 37, 23, 0.05),
+    0 14px 32px rgba(148, 107, 45, 0.14),
+    0 0 0 1px var(--tile-a, var(--accent2)) inset;
+}
+.pcard:hover::after { opacity: 1; }
+
+.pcard--dim {
+  opacity: 0.32;
+  filter: saturate(0.7);
+}
+.pcard--focus {
+  border-color: var(--tile-a, var(--accent2));
+  box-shadow:
+    0 2px 6px rgba(44, 37, 23, 0.06),
+    0 18px 40px rgba(148, 107, 45, 0.18),
+    0 0 0 1px var(--tile-a, var(--accent2)) inset;
+  transform: translateY(-2px);
+}
+
+.pcard-accent {
+  position: absolute; left: 0; top: 0; bottom: 0;
+  width: 3px;
+  background: linear-gradient(180deg, var(--tile-a, var(--accent2)), var(--tile-b, var(--accent)));
+  border-radius: 10px 0 0 10px;
+}
+
+.pcard-head {
+  display: flex; align-items: center; gap: 12px;
+}
+.pcard-avatar {
+  flex-shrink: 0;
+  border-radius: 50%;
+  background: linear-gradient(135deg, var(--tile-a), var(--tile-b));
+  color: #fff;
+  font-weight: 700;
+  letter-spacing: 0.02em;
+  display: flex; align-items: center; justify-content: center;
+  box-shadow:
+    inset 0 1px 0 rgba(255,255,255,0.25),
+    0 2px 6px rgba(44, 37, 23, 0.12);
+  font-family: var(--font-sans);
+}
+.pcard-headtext { min-width: 0; flex: 1; }
+.pcard-name {
+  font-family: var(--font-serif);
+  font-weight: 500;
+  font-size: 1.02rem;
+  color: var(--text);
+  letter-spacing: -0.01em;
+  line-height: 1.2;
+  margin-bottom: 2px;
+  white-space: nowrap; overflow: hidden; text-overflow: ellipsis;
+}
+.pcard-role {
+  font-size: 0.78rem;
+  color: var(--tile-ink, var(--text-dim));
+  font-weight: 500;
+  line-height: 1.3;
+  letter-spacing: 0.01em;
+}
+.pcard-crown {
+  color: var(--accent3);
+  font-size: 0.9rem;
+  margin-left: 4px;
+}
+
+.pcard-meta {
+  margin-top: 10px;
+  display: flex; gap: 10px; align-items: center;
+  font-family: var(--font-mono);
+  font-size: 0.66rem; color: var(--muted);
+  letter-spacing: 0.03em;
+  text-transform: uppercase;
+}
+.pcard-loc {
+  display: inline-flex; align-items: center; gap: 4px;
+}
+.pcard-tenure {
+  padding: 2px 7px;
+  background: var(--accent-dim);
+  border: 1px solid rgba(184, 134, 11, 0.22);
+  border-radius: 100px;
+  color: var(--accent);
+  font-weight: 600;
+}
+
+.pcard-body {
+  margin-top: 10px;
+  font-size: 0.8rem;
+  line-height: 1.5;
+  color: var(--text-dim);
+  display: -webkit-box;
+  -webkit-line-clamp: 2;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
+}
+
+.pcard-hoverchip {
+  position: absolute;
+  right: 14px; bottom: 12px;
+  font-size: 0.68rem;
+  color: var(--accent);
+  font-weight: 600;
+  letter-spacing: 0.02em;
+  opacity: 0;
+  transform: translateX(-4px);
+  transition: opacity 200ms ease, transform 200ms ease;
+  pointer-events: none;
+}
+.pcard:hover .pcard-hoverchip {
+  opacity: 1;
+  transform: translateX(0);
+}
+
+/* Expanded state */
+.pcard--expanded {
+  box-shadow:
+    0 4px 10px rgba(44, 37, 23, 0.08),
+    0 24px 56px rgba(148, 107, 45, 0.18),
+    0 0 0 1.5px var(--tile-a, var(--accent2)) inset;
+  transform: translateY(-4px) scale(1.02);
+  z-index: 5;
+}
+.pcard-expanded {
+  margin-top: 14px;
+  padding-top: 14px;
+  border-top: 1px dashed var(--border);
+  animation: expandFade 280ms ease;
+}
+@keyframes expandFade {
+  from { opacity: 0; transform: translateY(-4px); }
+  to   { opacity: 1; transform: translateY(0); }
+}
+.pcard-expanded-body {
+  font-size: 0.82rem;
+  line-height: 1.55;
+  color: var(--text-dim);
+}
+.pcard-actions { margin-top: 12px; }
+.pcard-cta {
+  display: inline-flex; align-items: center; gap: 4px;
+  font-size: 0.78rem;
+  color: var(--accent);
+  font-weight: 600;
+  padding: 6px 0;
+  border-bottom: 1px solid transparent;
+  transition: border-color 200ms ease, color 200ms ease;
+  text-decoration: none;
+}
+.pcard-cta:hover {
+  color: var(--accent2);
+  border-bottom-color: var(--accent2);
+}
+
+/* Responsive — org chart */
+@media (max-width: 900px) {
+  .page-header--observatory { padding: 28px 20px 24px; }
+  .page-header--observatory h1 { font-size: 1.9rem; }
+  .ph-stats { gap: 24px; }
+  .org-controls { padding: 0 20px; top: 60px; }
+  .org-controls-inner { min-height: auto; padding: 12px 0; }
+  .org-search { width: 100%; }
+  .legend { margin-left: 0; }
+  .org-main { padding: 20px; }
+}

--- a/app/org-chart/page.tsx
+++ b/app/org-chart/page.tsx
@@ -16,35 +16,84 @@ type SanityPerson = {
   name: string;
   slug: { current: string };
   role: string;
+  body?: string;
+  tags?: string[];
   reportsTo?: { slug: { current: string } } | null;
 };
 
+export type Member = {
+  slug: string;
+  name: string;
+  role: string;
+  reportsTo: string | null;
+  body: string;
+  location: string;
+  tenure: string;
+};
+
+const TENURE_TAGS = new Set(["Co-Founder", "Founding team", "Founding Team"]);
+
+function extractLocationAndTenure(tags: string[] | undefined): { location: string; tenure: string } {
+  if (!tags || !tags.length) return { location: "", tenure: "" };
+  let location = "";
+  let tenure = "";
+  for (const t of tags) {
+    if (TENURE_TAGS.has(t)) {
+      if (!tenure) tenure = t === "Founding Team" ? "Founding team" : t;
+    } else if (!location) {
+      location = t;
+    }
+  }
+  return { location, tenure };
+}
+
 export default async function OrgChartPage() {
-  let team: { slug: string; name: string; role: string; reportsTo: string | null }[] =
-    teamData.map((m) => ({ slug: m.slug, name: m.name, role: m.role, reportsTo: m.reportsTo }));
+  let team: Member[] = teamData.map((m) => {
+    const { location, tenure } = extractLocationAndTenure(m.tags);
+    return {
+      slug: m.slug,
+      name: m.name,
+      role: m.role,
+      reportsTo: m.reportsTo,
+      body: m.body || "",
+      location,
+      tenure,
+    };
+  });
 
   try {
     const persons: SanityPerson[] = await client.fetch(allPersonsQuery, {}, { perspective: "published" });
     if (persons?.length) {
       const sanityMap = new Map(
-        persons.map((p) => [p.slug.current, {
-          slug: p.slug.current,
-          name: p.name,
-          role: p.role,
-          reportsTo: p.reportsTo?.slug?.current ?? null,
-        }])
-      );
-      // Override static entries with Sanity data where a match exists, add new Sanity-only entries
-      team = [
-        ...team.map((m) => sanityMap.get(m.slug) ?? m),
-        ...persons
-          .filter((p) => !team.some((m) => m.slug === p.slug.current))
-          .map((p) => ({
+        persons.map((p) => {
+          const { location, tenure } = extractLocationAndTenure(p.tags);
+          return [p.slug.current, {
             slug: p.slug.current,
             name: p.name,
             role: p.role,
             reportsTo: p.reportsTo?.slug?.current ?? null,
-          })),
+            body: typeof p.body === "string" ? p.body : "",
+            location,
+            tenure,
+          }];
+        })
+      );
+      team = [
+        ...team.map((m) => sanityMap.get(m.slug) ?? m),
+        ...persons
+          .filter((p) => !team.some((m) => m.slug === p.slug.current))
+          .map((p) => {
+            const { location, tenure } = extractLocationAndTenure(p.tags);
+            return {
+              slug: p.slug.current,
+              name: p.name,
+              role: p.role,
+              reportsTo: p.reportsTo?.slug?.current ?? null,
+              body: typeof p.body === "string" ? p.body : "",
+              location,
+              tenure,
+            };
+          }),
       ];
     }
   } catch (err) {

--- a/components/OrgChartClient.tsx
+++ b/components/OrgChartClient.tsx
@@ -1,330 +1,533 @@
 "use client";
-import { useEffect, useRef, useState } from "react";
-import * as d3 from "d3";
-import { useRouter } from "next/navigation";
+import { useMemo, useState } from "react";
+import Link from "next/link";
 
 type Member = {
   slug: string;
   name: string;
   role: string;
   reportsTo: string | null;
+  body: string;
+  location: string;
+  tenure: string;
 };
 
-type TreeNode = {
-  slug: string;
-  name: string;
-  role: string;
-  children?: TreeNode[];
+type ColorTriplet = { a: string; b: string; ink: string };
+
+const PALETTE: Record<string, ColorTriplet> = {
+  chairman:  { a: "#B8860B", b: "#946B2D", ink: "#6B4E1F" },
+  exec:      { a: "#C07A3A", b: "#9E5F28", ink: "#7A4618" },
+  ops:       { a: "#A85C72", b: "#87445A", ink: "#6B3347" },
+  science:   { a: "#2A7D6B", b: "#1F5E50", ink: "#17453B" },
+  research:  { a: "#3D7A4A", b: "#2B5A36", ink: "#1F4427" },
+  singapore: { a: "#4A7FA5", b: "#345E7C", ink: "#26455C" },
+  fallback:  { a: "#8C8474", b: "#6B6355", ink: "#4A3F30" },
 };
 
-function buildTree(team: Member[]): TreeNode {
+const PERSON_COLOR: Record<string, ColorTriplet> = {
+  "yann-lecun":       PALETTE.chairman,
+  "alexandre-lebrun": PALETTE.exec,
+  "laurent-solly":    PALETTE.ops,
+  "sean-nguyen":      PALETTE.ops,
+  "saining-xie":      PALETTE.science,
+  "pascale-fung":     PALETTE.science,
+  "min-lin":          PALETTE.singapore,
+  "brian-li":         PALETTE.singapore,
+  "michael-rabbat":   PALETTE.research,
+  "li-jing":          PALETTE.research,
+  "xingyi-zhou":      PALETTE.research,
+  "sanghyun-woo":     PALETTE.research,
+  "delong-chen":      PALETTE.research,
+  "david-fan":        PALETTE.research,
+  "xinyi-wan":        PALETTE.research,
+  "jihan-yang":       PALETTE.research,
+};
+
+function colorFor(slug: string, role: string): ColorTriplet {
+  const explicit = PERSON_COLOR[slug];
+  if (explicit) return explicit;
+  const r = role.toLowerCase();
+  if (/chairman/.test(r)) return PALETTE.chairman;
+  if (/\bceo\b/.test(r)) return PALETTE.exec;
+  if (/\bcoo\b|operations/.test(r)) return PALETTE.ops;
+  if (/chief|science/.test(r)) return PALETTE.science;
+  if (/singapore/.test(r)) return PALETTE.singapore;
+  if (/research|scientist|technical staff|pretraining|world models/.test(r)) return PALETTE.research;
+  return PALETTE.fallback;
+}
+
+function initialsOf(name: string): string {
+  return name
+    .replace(/[^A-Za-z\s-]/g, "")
+    .split(/\s+/)
+    .filter(Boolean)
+    .map((w) => w[0])
+    .slice(0, 2)
+    .join("")
+    .toUpperCase();
+}
+
+const DEFAULT_PARENT_FOR_ORPHANS = "saining-xie";
+
+type TreeNode = Member & { children: TreeNode[] };
+
+function buildTree(team: Member[]): TreeNode | null {
   const map = new Map<string, TreeNode>();
-  team.forEach((m) => map.set(m.slug, { slug: m.slug, name: m.name, role: m.role, children: [] }));
+  team.forEach((m) => map.set(m.slug, { ...m, children: [] }));
 
   let root: TreeNode | null = null;
   const orphans: TreeNode[] = [];
 
   for (const m of team) {
+    const node = map.get(m.slug)!;
     if (!m.reportsTo) {
-      if (!root) {
-        root = map.get(m.slug)!;
-      } else {
-        orphans.push(map.get(m.slug)!);
-      }
+      if (!root) root = node;
+      else orphans.push(node);
     } else {
       const parent = map.get(m.reportsTo);
-      if (parent) {
-        parent.children = [...(parent.children || []), map.get(m.slug)!];
-      } else {
-        orphans.push(map.get(m.slug)!);
-      }
+      if (parent) parent.children.push(node);
+      else orphans.push(node);
     }
   }
 
-  if (root && orphans.length) {
-    root.children = [...(root.children || []), ...orphans];
+  if (orphans.length) {
+    const fallbackParent = map.get(DEFAULT_PARENT_FOR_ORPHANS);
+    if (fallbackParent) {
+      fallbackParent.children.push(...orphans);
+    } else if (root) {
+      root.children.push(...orphans);
+    }
   }
 
-  for (const node of map.values()) {
-    if (!node.children?.length) delete node.children;
-  }
-
-  return root!;
+  return root;
 }
 
-const AVATAR_COLORS = [
-  ["#946B2D", "#B8960B"], ["#2A7D6B", "#3D9E88"], ["#3D7A4A", "#5EA06A"],
-  ["#C07A3A", "#D99B5C"], ["#A85C72", "#C8849A"], ["#7B5EA7", "#9D84C4"],
-  ["#4A7FA5", "#6FA3C4"], ["#5C8A5E", "#7FAE82"],
+type Positioned = { node: TreeNode; x: number; y: number; depth: number };
+
+function layoutTree(
+  root: TreeNode,
+  opts: { nodeW: number; nodeH: number; hGap: number; vGap: number }
+): { nodes: Positioned[]; width: number; height: number } {
+  const { nodeW, nodeH, hGap, vGap } = opts;
+  let cursor = 0;
+  const xByNode = new Map<TreeNode, number>();
+
+  function walk(n: TreeNode) {
+    if (!n.children.length) {
+      xByNode.set(n, cursor);
+      cursor += nodeW + hGap;
+    } else {
+      n.children.forEach(walk);
+      const first = xByNode.get(n.children[0])!;
+      const last = xByNode.get(n.children[n.children.length - 1])!;
+      xByNode.set(n, (first + last) / 2);
+    }
+  }
+  walk(root);
+
+  function shift(n: TreeNode, delta: number) {
+    xByNode.set(n, (xByNode.get(n) ?? 0) + delta);
+    n.children.forEach((c) => shift(c, delta));
+  }
+  function contours(n: TreeNode): { left: number[]; right: number[] } {
+    const left: number[] = [];
+    const right: number[] = [];
+    function rec(m: TreeNode, d: number) {
+      const x = xByNode.get(m)!;
+      if (left[d] === undefined || x < left[d]) left[d] = x;
+      if (right[d] === undefined || x > right[d]) right[d] = x;
+      m.children.forEach((c) => rec(c, d + 1));
+    }
+    rec(n, 0);
+    return { left, right };
+  }
+  function resolve(n: TreeNode) {
+    if (n.children.length < 2) {
+      n.children.forEach(resolve);
+      return;
+    }
+    for (let i = 1; i < n.children.length; i++) {
+      const left = n.children[i - 1];
+      const right = n.children[i];
+      const lc = contours(left).right;
+      const rc = contours(right).left;
+      let maxOverlap = 0;
+      const depthCount = Math.min(lc.length, rc.length);
+      for (let d = 0; d < depthCount; d++) {
+        const need = lc[d] + nodeW + hGap;
+        const gap = rc[d] - need;
+        if (gap < 0 && -gap > maxOverlap) maxOverlap = -gap;
+      }
+      if (maxOverlap > 0) shift(right, maxOverlap);
+    }
+    const first = xByNode.get(n.children[0])!;
+    const last = xByNode.get(n.children[n.children.length - 1])!;
+    xByNode.set(n, (first + last) / 2);
+    n.children.forEach(resolve);
+  }
+  resolve(root);
+
+  const all: Positioned[] = [];
+  function collect(n: TreeNode, depth: number) {
+    all.push({ node: n, x: xByNode.get(n)!, y: depth * (nodeH + vGap), depth });
+    n.children.forEach((c) => collect(c, depth + 1));
+  }
+  collect(root, 0);
+
+  const minX = Math.min(...all.map((p) => p.x));
+  all.forEach((p) => (p.x -= minX));
+
+  const maxX = Math.max(...all.map((p) => p.x)) + nodeW;
+  const maxY = Math.max(...all.map((p) => p.y)) + nodeH;
+  return { nodes: all, width: maxX, height: maxY };
+}
+
+function ancestorsOf(team: Member[], slug: string): Set<string> {
+  const map = new Map(team.map((m) => [m.slug, m]));
+  const out = new Set<string>();
+  let cur: Member | undefined = map.get(slug);
+  while (cur) {
+    out.add(cur.slug);
+    cur = cur.reportsTo ? map.get(cur.reportsTo) : undefined;
+  }
+  return out;
+}
+
+function descendantsOf(team: Member[], slug: string): Set<string> {
+  const kidsByParent = new Map<string, string[]>();
+  team.forEach((m) => {
+    if (!m.reportsTo) return;
+    if (!kidsByParent.has(m.reportsTo)) kidsByParent.set(m.reportsTo, []);
+    kidsByParent.get(m.reportsTo)!.push(m.slug);
+  });
+  const out = new Set<string>([slug]);
+  const stack = [slug];
+  while (stack.length) {
+    const cur = stack.pop()!;
+    const kids = kidsByParent.get(cur) || [];
+    kids.forEach((k) => {
+      if (!out.has(k)) {
+        out.add(k);
+        stack.push(k);
+      }
+    });
+  }
+  return out;
+}
+
+const NODE_W = 280;
+const NODE_H = 132;
+const H_GAP = 32;
+const V_GAP = 92;
+const PAD = 56;
+
+function MapPin() {
+  return (
+    <svg width="10" height="10" viewBox="0 0 16 16" fill="none" aria-hidden>
+      <path
+        d="M8 1.5a4.5 4.5 0 0 0-4.5 4.5c0 3.38 4.5 8.5 4.5 8.5s4.5-5.12 4.5-8.5A4.5 4.5 0 0 0 8 1.5Zm0 6.25a1.75 1.75 0 1 1 0-3.5 1.75 1.75 0 0 1 0 3.5Z"
+        fill="currentColor"
+      />
+    </svg>
+  );
+}
+
+function SearchIcon() {
+  return (
+    <svg
+      width="16"
+      height="16"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="2"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+    >
+      <circle cx="11" cy="11" r="7" />
+      <path d="m20 20-3.35-3.35" />
+    </svg>
+  );
+}
+
+type LegendItem = { key: keyof typeof PALETTE; label: string };
+const LEGEND: LegendItem[] = [
+  { key: "chairman", label: "Chairman" },
+  { key: "exec", label: "CEO" },
+  { key: "ops", label: "Operations" },
+  { key: "science", label: "Science" },
+  { key: "research", label: "Research" },
+  { key: "singapore", label: "Singapore" },
 ];
 
-function getColor(name: string) {
-  const i = name.charCodeAt(0) % AVATAR_COLORS.length;
-  return AVATAR_COLORS[i];
-}
-
-function initials(name: string) {
-  return name.split(/\s+/).map((w) => w[0]).join("").slice(0, 2).toUpperCase();
-}
-
-type TooltipState = {
-  name: string;
-  role: string;
-  slug: string;
-  x: number;
-  y: number;
-} | null;
+const FOUNDER_TENURES = new Set(["Co-Founder"]);
 
 export default function OrgChartClient({ team }: { team: Member[] }) {
-  const svgRef = useRef<SVGSVGElement>(null);
-  const containerRef = useRef<HTMLDivElement>(null);
-  const router = useRouter();
-  const [tooltip, setTooltip] = useState<TooltipState>(null);
+  const [hover, setHover] = useState<string | null>(null);
+  const [expanded, setExpanded] = useState<string | null>(null);
+  const [query, setQuery] = useState("");
 
-  useEffect(() => {
-    if (!svgRef.current) return;
+  const layout = useMemo(() => {
+    const tree = buildTree(team);
+    if (!tree) return { nodes: [] as Positioned[], width: 0, height: 0 };
+    return layoutTree(tree, { nodeW: NODE_W, nodeH: NODE_H, hGap: H_GAP, vGap: V_GAP });
+  }, [team]);
 
-    const treeData = buildTree(team);
-    const root = d3.hierarchy(treeData);
+  const focusSlug = expanded ?? hover;
 
-    const nodeW = 216;  // 180 × 1.2
-    const nodeH = 96;   // 80 × 1.2
-    const vertGap = 144;
-    const horizGap = 240;
+  const lineage = useMemo(() => {
+    if (!focusSlug) return null;
+    const anc = ancestorsOf(team, focusSlug);
+    const dsc = descendantsOf(team, focusSlug);
+    return new Set<string>([...anc, ...dsc]);
+  }, [focusSlug, team]);
 
-    const treeLayout = d3.tree<TreeNode>()
-      .nodeSize([horizGap, vertGap + nodeH]);
+  const matchedSet = useMemo(() => {
+    const q = query.trim().toLowerCase();
+    if (!q) return null;
+    return new Set(
+      team
+        .filter(
+          (m) =>
+            m.name.toLowerCase().includes(q) ||
+            m.role.toLowerCase().includes(q) ||
+            (m.location || "").toLowerCase().includes(q)
+        )
+        .map((m) => m.slug)
+    );
+  }, [query, team]);
 
-    treeLayout(root);
+  const stats = useMemo(() => {
+    const total = team.length;
+    const founders = team.filter((m) => FOUNDER_TENURES.has(m.tenure)).length;
+    const cities = new Set(
+      team
+        .map((m) => (m.location || "").split("/")[0].trim())
+        .filter((l) => l && l !== "—")
+    );
+    return { total, founders, cities: cities.size };
+  }, [team]);
 
-    const nodes = root.descendants();
-    const links = root.links();
+  const lastUpdated = useMemo(() => {
+    const d = new Date();
+    return d.toLocaleString("en-US", { month: "short", year: "numeric" });
+  }, []);
 
-    const xs = nodes.map((n) => n.x ?? 0);
-    const ys = nodes.map((n) => n.y ?? 0);
-    const minX = Math.min(...xs) - nodeW / 2 - 20;
-    const maxX = Math.max(...xs) + nodeW / 2 + 20;
-    const minY = Math.min(...ys) - nodeH / 2 - 20;
-    const maxY = Math.max(...ys) + nodeH / 2 + 40;
+  const canvasW = layout.width + PAD * 2;
+  const canvasH = layout.height + PAD * 2;
 
-    const width = maxX - minX;
-    const height = maxY - minY;
+  // Build connector links from positions
+  const positionsBySlug = useMemo(() => {
+    const m = new Map<string, Positioned>();
+    layout.nodes.forEach((p) => m.set(p.node.slug, p));
+    return m;
+  }, [layout]);
 
-    const svg = d3.select(svgRef.current);
-    svg.selectAll("*").remove();
-    svg.attr("viewBox", `${minX} ${minY} ${width} ${height}`)
-      .attr("width", "100%")
-      .attr("height", height)
-      .style("max-height", "720px");
-
-    // Draw links
-    svg.append("g")
-      .selectAll("path")
-      .data(links)
-      .enter()
-      .append("path")
-      .attr("fill", "none")
-      .style("stroke", "var(--border)")
-      .attr("stroke-width", 1.5)
-      .attr("d", (d) => {
-        const sx = d.source.x ?? 0, sy = (d.source.y ?? 0) + nodeH / 2;
-        const tx = d.target.x ?? 0, ty = (d.target.y ?? 0) - nodeH / 2;
-        const my = (sy + ty) / 2;
-        return `M${sx},${sy} C${sx},${my} ${tx},${my} ${tx},${ty}`;
-      });
-
-    // Define gradients
-    const defs = svg.append("defs");
-    nodes.forEach((d) => {
-      const [a, b] = getColor(d.data.name);
-      const grad = defs.append("linearGradient")
-        .attr("id", `grad-${d.data.slug}`)
-        .attr("x1", "0%").attr("y1", "0%")
-        .attr("x2", "100%").attr("y2", "100%");
-      grad.append("stop").attr("offset", "0%").attr("stop-color", a);
-      grad.append("stop").attr("offset", "100%").attr("stop-color", b);
+  const links = useMemo(() => {
+    const out: { from: Positioned; to: Positioned }[] = [];
+    layout.nodes.forEach((p) => {
+      const parentSlug = p.node.reportsTo;
+      if (!parentSlug) return;
+      const parent = positionsBySlug.get(parentSlug);
+      if (!parent) return;
+      out.push({ from: parent, to: p });
     });
+    return out;
+  }, [layout, positionsBySlug]);
 
-    // Draw nodes
-    const nodeGroup = svg.append("g")
-      .selectAll("g")
-      .data(nodes)
-      .enter()
-      .append("g")
-      .attr("transform", (d) => `translate(${(d.x ?? 0) - nodeW / 2},${(d.y ?? 0) - nodeH / 2})`)
-      .style("cursor", "pointer")
-      .on("click", (_, d) => router.push(`/team/${d.data.slug}`))
-      .on("mouseenter", function (event: MouseEvent, d) {
-        d3.select(this).select("rect").style("stroke", "var(--accent)");
-        setTooltip({
-          name: d.data.name,
-          role: d.data.role,
-          slug: d.data.slug,
-          x: event.clientX,
-          y: event.clientY,
-        });
-      })
-      .on("mouseleave", function () {
-        d3.select(this).select("rect").style("stroke", "var(--border)");
-        setTooltip(null);
-      });
-
-    nodeGroup.append("rect")
-      .attr("width", nodeW)
-      .attr("height", nodeH)
-      .attr("rx", 12)
-      .style("fill", "var(--surface)")
-      .style("stroke", "var(--border)")
-      .attr("stroke-width", 1);
-
-    // Avatar circle
-    nodeGroup.append("circle")
-      .attr("cx", 36)
-      .attr("cy", nodeH / 2)
-      .attr("r", 22)
-      .attr("fill", (d) => `url(#grad-${d.data.slug})`);
-
-    // Initials text
-    nodeGroup.append("text")
-      .attr("x", 36)
-      .attr("y", nodeH / 2 + 5)
-      .attr("text-anchor", "middle")
-      .attr("fill", "#fff")
-      .attr("font-size", "13px")
-      .attr("font-weight", "700")
-      .text((d) => initials(d.data.name));
-
-    // Name text
-    nodeGroup.append("text")
-      .attr("x", 68)
-      .attr("y", nodeH / 2 - 10)
-      .style("fill", "var(--text)")
-      .attr("font-size", "13px")
-      .attr("font-weight", "600")
-      .attr("font-family", "-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif")
-      .text((d) => d.data.name.length > 20 ? d.data.name.slice(0, 19) + "…" : d.data.name);
-
-    // Role text
-    nodeGroup.append("text")
-      .attr("x", 68)
-      .attr("y", nodeH / 2 + 10)
-      .style("fill", "var(--muted)")
-      .attr("font-size", "11px")
-      .attr("font-family", "-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif")
-      .text((d) => d.data.role.length > 26 ? d.data.role.slice(0, 25) + "…" : d.data.role);
-
-  }, [team, router]);
-
-  // Clamp tooltip so it doesn't overflow viewport
-  const TOOLTIP_W = 300;
-  const TOOLTIP_H = 110;
-  const tooltipStyle = tooltip ? {
-    left: Math.min(tooltip.x + 18, (typeof window !== "undefined" ? window.innerWidth : 1200) - TOOLTIP_W - 8),
-    top: Math.min(tooltip.y - 20, (typeof window !== "undefined" ? window.innerHeight : 800) - TOOLTIP_H - 8),
-  } : null;
-
-  const tooltipColors = tooltip ? getColor(tooltip.name) : ["#946B2D", "#B8960B"];
+  function pathFor(from: Positioned, to: Positioned): string {
+    const sx = from.x + PAD + NODE_W / 2;
+    const sy = from.y + PAD + NODE_H;
+    const tx = to.x + PAD + NODE_W / 2;
+    const ty = to.y + PAD;
+    const my = sy + (ty - sy) / 2;
+    return `M ${sx} ${sy} C ${sx} ${my}, ${tx} ${my}, ${tx} ${ty}`;
+  }
 
   return (
     <>
-      <div className="page-header">
+      <header className="page-header page-header--observatory">
         <div className="page-header-inner">
+          <div className="ph-eyebrow">
+            <span className="ph-dot" /> The Observatory · Organization
+          </div>
           <h1>AMI Labs Org Chart</h1>
-          <p>Click any node to view the full profile. Hierarchy based on publicly available information.</p>
+          <p>
+            Reporting structure inferred from public announcements and LinkedIn.
+            Hover a card to trace its reporting line; click to expand.
+          </p>
+          <div className="ph-stats">
+            <div className="ph-stat">
+              <div className="ph-stat-num">{stats.total}</div>
+              <div className="ph-stat-label">People mapped</div>
+            </div>
+            <div className="ph-stat">
+              <div className="ph-stat-num">{stats.founders}</div>
+              <div className="ph-stat-label">Co-Founders</div>
+            </div>
+            <div className="ph-stat">
+              <div className="ph-stat-num">{stats.cities}</div>
+              <div className="ph-stat-label">Cities</div>
+            </div>
+            <div className="ph-stat ph-stat--update">
+              <div className="ph-stat-num">{lastUpdated}</div>
+              <div className="ph-stat-label">Last updated</div>
+            </div>
+          </div>
+        </div>
+      </header>
+
+      <div className="org-controls">
+        <div className="org-controls-inner">
+          <div className="org-search">
+            <SearchIcon />
+            <input
+              type="search"
+              placeholder="Search people, roles, or locations…"
+              value={query}
+              onChange={(e) => setQuery(e.target.value)}
+            />
+          </div>
+          <div className="legend">
+            {LEGEND.map((item) => (
+              <span className="legend-dot" key={item.key}>
+                <span className="legend-swatch" style={{ background: PALETTE[item.key].a }} />
+                {item.label}
+              </span>
+            ))}
+          </div>
         </div>
       </div>
-      <main>
-        <div
-          ref={containerRef}
-          style={{
-            background: "var(--surface)",
-            border: "1px solid var(--border)",
-            borderRadius: "12px",
-            padding: "24px",
-            overflowX: "auto",
-          }}
-        >
-          <svg ref={svgRef} />
+
+      <main className="org-main">
+        <div className="org-canvas-wrap">
+          <div className="org-canvas" style={{ width: canvasW, height: canvasH }}>
+            <svg
+              className="org-connectors"
+              width={canvasW}
+              height={canvasH}
+              viewBox={`0 0 ${canvasW} ${canvasH}`}
+              aria-hidden
+            >
+              {links.map((l) => {
+                const onLineage =
+                  lineage &&
+                  lineage.has(l.from.node.slug) &&
+                  lineage.has(l.to.node.slug);
+                const dim = lineage && !onLineage;
+                const cls = `org-link${dim ? " org-link--dim" : ""}${onLineage ? " org-link--focus" : ""}`;
+                return (
+                  <path
+                    key={`${l.from.node.slug}-${l.to.node.slug}`}
+                    d={pathFor(l.from, l.to)}
+                    className={cls}
+                    style={{ animationDelay: `${160 + l.to.depth * 90}ms` }}
+                  />
+                );
+              })}
+            </svg>
+
+            {layout.nodes.map((p, i) => {
+              const matched = matchedSet ? matchedSet.has(p.node.slug) : null;
+              const lineageHit = lineage ? lineage.has(p.node.slug) : null;
+
+              let highlight: "dim" | "focus" | null = null;
+              if (matched === false) highlight = "dim";
+              if (lineage && !lineageHit) highlight = "dim";
+              if (lineage && lineageHit) highlight = "focus";
+              if (matched === true && !lineage) highlight = "focus";
+
+              const color = colorFor(p.node.slug, p.node.role);
+              const isExpanded = expanded === p.node.slug;
+              const isRoot = !p.node.reportsTo;
+
+              return (
+                <div
+                  key={p.node.slug}
+                  className="org-node"
+                  style={{
+                    left: p.x + PAD,
+                    top: p.y + PAD,
+                    width: NODE_W,
+                    animationDelay: `${80 + p.depth * 90 + (i % 4) * 25}ms`,
+                  }}
+                >
+                  <div
+                    className={`pcard${highlight === "dim" ? " pcard--dim" : ""}${highlight === "focus" ? " pcard--focus" : ""}${isExpanded ? " pcard--expanded" : ""}`}
+                    style={{
+                      minHeight: NODE_H,
+                      ["--tile-a" as string]: color.a,
+                      ["--tile-b" as string]: color.b,
+                      ["--tile-ink" as string]: color.ink,
+                    }}
+                    onMouseEnter={() => setHover(p.node.slug)}
+                    onMouseLeave={() => setHover(null)}
+                    onClick={() => setExpanded((cur) => (cur === p.node.slug ? null : p.node.slug))}
+                  >
+                    <div className="pcard-accent" aria-hidden />
+
+                    <div className="pcard-head">
+                      <div
+                        className="pcard-avatar"
+                        style={{ width: 40, height: 40, fontSize: 16 }}
+                      >
+                        {initialsOf(p.node.name)}
+                      </div>
+                      <div className="pcard-headtext">
+                        <div className="pcard-name">{p.node.name}</div>
+                        <div className="pcard-role">{p.node.role}</div>
+                      </div>
+                      {isRoot && (
+                        <span className="pcard-crown" title="Executive Chairman" aria-hidden>
+                          ✦
+                        </span>
+                      )}
+                    </div>
+
+                    {(p.node.location || p.node.tenure) && (
+                      <div className="pcard-meta">
+                        {p.node.location && (
+                          <span className="pcard-loc">
+                            <MapPin /> {p.node.location}
+                          </span>
+                        )}
+                        {p.node.tenure && (
+                          <span className="pcard-tenure">{p.node.tenure}</span>
+                        )}
+                      </div>
+                    )}
+
+                    {p.node.body && <p className="pcard-body">{p.node.body}</p>}
+
+                    {isExpanded && (
+                      <div className="pcard-expanded">
+                        <div className="pcard-expanded-body">{p.node.body}</div>
+                        <div className="pcard-actions">
+                          <Link
+                            className="pcard-cta"
+                            href={`/team/${p.node.slug}`}
+                            onClick={(e) => e.stopPropagation()}
+                          >
+                            View full profile →
+                          </Link>
+                        </div>
+                      </div>
+                    )}
+
+                    <div className="pcard-hoverchip" aria-hidden>
+                      Click for profile →
+                    </div>
+                  </div>
+                </div>
+              );
+            })}
+          </div>
         </div>
-        <p style={{ color: "var(--muted)", fontSize: "0.78rem", marginTop: "12px", textAlign: "center" }}>
-          Reporting structure inferred from public announcements and LinkedIn.
+        <p className="org-footnote">
+          Reporting structure inferred from public announcements and LinkedIn ·
+          AMI Labs, Advanced Machine Intelligence
         </p>
       </main>
-
-      {tooltip && tooltipStyle && (
-        <div
-          style={{
-            position: "fixed",
-            left: tooltipStyle.left,
-            top: tooltipStyle.top,
-            width: TOOLTIP_W,
-            zIndex: 1000,
-            pointerEvents: "none",
-            background: "var(--bg)",
-            border: "1px solid var(--accent)",
-            borderRadius: "14px",
-            padding: "16px 20px",
-            boxShadow: "0 8px 32px rgba(148, 107, 45, 0.15), 0 2px 8px rgba(0,0,0,0.08)",
-            display: "flex",
-            alignItems: "center",
-            gap: "16px",
-            animation: "orgTooltipIn 0.12s ease-out",
-          }}
-        >
-          {/* Large avatar */}
-          <div style={{
-            flexShrink: 0,
-            width: 52,
-            height: 52,
-            borderRadius: "50%",
-            background: `linear-gradient(135deg, ${tooltipColors[0]}, ${tooltipColors[1]})`,
-            display: "flex",
-            alignItems: "center",
-            justifyContent: "center",
-            fontSize: "18px",
-            fontWeight: 700,
-            color: "#fff",
-            letterSpacing: "0.02em",
-          }}>
-            {initials(tooltip.name)}
-          </div>
-
-          {/* Text */}
-          <div style={{ minWidth: 0 }}>
-            <div style={{
-              color: "var(--text)",
-              fontSize: "15px",
-              fontWeight: 700,
-              lineHeight: 1.3,
-              marginBottom: "4px",
-            }}>
-              {tooltip.name}
-            </div>
-            <div style={{
-              color: "var(--muted)",
-              fontSize: "12px",
-              lineHeight: 1.4,
-              marginBottom: "8px",
-            }}>
-              {tooltip.role}
-            </div>
-            <div style={{
-              color: "var(--accent)",
-              fontSize: "11px",
-              fontWeight: 500,
-            }}>
-              Click to view profile →
-            </div>
-          </div>
-
-          <style>{`
-            @keyframes orgTooltipIn {
-              from { opacity: 0; transform: translateY(4px) scale(0.97); }
-              to   { opacity: 1; transform: translateY(0) scale(1); }
-            }
-          `}</style>
-        </div>
-      )}
     </>
   );
 }


### PR DESCRIPTION
Replace D3-SVG node rendering with HTML cards + SVG connector overlay.
- Department-based color palette (chairman/exec/ops/science/research/singapore) instead of hash-based rainbow
- Cards legible at rest: name, role, location, tenure pill, 2-line bio
- Pull location and tenure from tags on both team.json and Sanity path
- Tidy-tree layout with contour-based overlap resolution (no D3 dependency)
- Search bar + department legend in sticky control bar
- Click-to-expand inline bio with "View full profile" CTA to /team/[slug]
- Hover traces ancestor + descendant reporting line; off-lineage cards dim
- Staggered entrance + connector draw-in animations
- Extended page header with eyebrow, stats (people / founders / cities)
- Orphan researchers pinned under Saining Xie instead of under the root
- All new styles are additively namespaced (.pcard, .org-*, .ph-*)

https://claude.ai/code/session_012PDqzBhK1oSCLLaAVWHhRz