### PR TITLE
Auto-convert YouTube/Vimeo URLs to embed format in article videos

### DIFF
--- a/app/news/[slug]/page.tsx
+++ b/app/news/[slug]/page.tsx
@@ -58,23 +58,31 @@ const portableTextComponents = {
         )}
       </figure>
     ),
-    videoEmbed: ({ value }: { value: { url: string; caption?: string } }) => (
-      <figure style={{ margin: "2rem 0" }}>
-        <div style={{ position: "relative", paddingBottom: "56.25%", height: 0, overflow: "hidden", borderRadius: "8px" }}>
-          <iframe
-            src={value.url}
-            style={{ position: "absolute", top: 0, left: 0, width: "100%", height: "100%", border: 0 }}
-            allowFullScreen
-            title={value.caption ?? "Video"}
-          />
-        </div>
-        {value.caption && (
-          <figcaption style={{ marginTop: "8px", fontSize: "0.8rem", color: "var(--muted)", textAlign: "center" }}>
-            {value.caption}
-          </figcaption>
-        )}
-      </figure>
-    ),
+    videoEmbed: ({ value }: { value: { url: string; caption?: string } }) => {
+      let src = value.url;
+      const yt = src.match(/(?:youtube\.com\/watch\?v=|youtu\.be\/|youtube\.com\/embed\/)([\w-]+)/);
+      if (yt) src = `https://www.youtube.com/embed/${yt[1]}`;
+      const vimeo = !yt && src.match(/vimeo\.com\/(\d+)/);
+      if (vimeo) src = `https://player.vimeo.com/video/${vimeo[1]}`;
+      return (
+        <figure style={{ margin: "2rem 0" }}>
+          <div style={{ position: "relative", paddingBottom: "56.25%", height: 0, overflow: "hidden", borderRadius: "8px" }}>
+            <iframe
+              src={src}
+              style={{ position: "absolute", top: 0, left: 0, width: "100%", height: "100%", border: 0 }}
+              allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
+              allowFullScreen
+              title={value.caption ?? "Video"}
+            />
+          </div>
+          {value.caption && (
+            <figcaption style={{ marginTop: "8px", fontSize: "0.8rem", color: "var(--muted)", textAlign: "center" }}>
+              {value.caption}
+            </figcaption>
+          )}
+        </figure>
+      );
+    },
   },
   block: {
     h1: ({ children }: { children?: React.ReactNode }) => (


### PR DESCRIPTION
Regular YouTube watch URLs (youtube.com/watch?v=...) get blocked by X-Frame-Options when used in iframes. The videoEmbed renderer now auto-detects and converts:
- youtube.com/watch?v=ID → youtube.com/embed/ID
- youtu.be/ID → youtube.com/embed/ID
- vimeo.com/ID → player.vimeo.com/video/ID
- Already-correct embed URLs pass through unchanged

Also added the allow attribute for YouTube's recommended permissions.

https://claude.ai/code/session_012PDqzBhK1oSCLLaAVWHhRz